### PR TITLE
Enhance service generation of Nacos Registry, now Nacos service name …

### DIFF
--- a/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -170,19 +170,19 @@ public class NacosRegistry extends Registry {
                         String serviceName = instance.getServiceName();
                         if (LOGGER.isInfoEnabled(appName)) {
                             LOGGER.infoWithApp(appName,
-                                    LogCodes.getLog(LogCodes.INFO_ROUTE_REGISTRY_PUB_START, serviceName));
+                                LogCodes.getLog(LogCodes.INFO_ROUTE_REGISTRY_PUB_START, serviceName));
                         }
                         namingService.registerInstance(serviceName, instance);
                         if (LOGGER.isInfoEnabled(appName)) {
                             LOGGER.infoWithApp(appName,
-                                    LogCodes.getLog(LogCodes.INFO_ROUTE_REGISTRY_PUB_OVER, serviceName));
+                                LogCodes.getLog(LogCodes.INFO_ROUTE_REGISTRY_PUB_OVER, serviceName));
                         }
                     }
                     providerInstances.put(config, instances);
                 }
             } catch (Exception e) {
                 throw new SofaRpcRuntimeException("Failed to register provider to nacosRegistry! service: "
-                        + config.buildKey(), e);
+                    + config.buildKey(), e);
             }
         }
     }
@@ -209,7 +209,7 @@ public class NacosRegistry extends Registry {
                             instance.getClusterName());
                         if (LOGGER.isInfoEnabled(appName)) {
                             LOGGER.infoWithApp(appName, LogCodes.getLog(LogCodes.INFO_ROUTE_REGISTRY_UNPUB,
-                                    serviceName, instances.size()));
+                                serviceName, instances.size()));
                         }
                     }
                 }
@@ -218,7 +218,7 @@ public class NacosRegistry extends Registry {
                 if (!RpcRunningState.isShuttingDown()) {
                     throw new SofaRpcRuntimeException(
                         "Failed to unregister provider to nacos registry! service: "
-                                + config.buildKey(), e);
+                            + config.buildKey(), e);
                 }
             }
         }

--- a/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelper.java
+++ b/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelper.java
@@ -55,9 +55,9 @@ class NacosRegistryHelper {
      * @param protocol protocol for config
      * @return unique service name
      */
-    static String buildServiceName(AbstractInterfaceConfig config, String protocol){
-        if(RpcConstants.PROTOCOL_TYPE_BOLT.equals(protocol)
-                || RpcConstants.PROTOCOL_TYPE_TR.equals(protocol)){
+    static String buildServiceName(AbstractInterfaceConfig config, String protocol) {
+        if (RpcConstants.PROTOCOL_TYPE_BOLT.equals(protocol)
+            || RpcConstants.PROTOCOL_TYPE_TR.equals(protocol)) {
             return ConfigUniqueNameGenerator.getServiceName(config) + ":DEFAULT";
         } else {
             return ConfigUniqueNameGenerator.getServiceName(config) + ":" + protocol;

--- a/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelper.java
+++ b/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelper.java
@@ -24,6 +24,8 @@ import com.alipay.sofa.rpc.common.SystemInfo;
 import com.alipay.sofa.rpc.common.utils.CommonUtils;
 import com.alipay.sofa.rpc.common.utils.NetUtils;
 import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.AbstractInterfaceConfig;
+import com.alipay.sofa.rpc.config.ConfigUniqueNameGenerator;
 import com.alipay.sofa.rpc.config.ProviderConfig;
 import com.alipay.sofa.rpc.config.ServerConfig;
 import com.alipay.sofa.rpc.registry.utils.RegistryUtils;
@@ -42,6 +44,27 @@ class NacosRegistryHelper {
     static final String DEFAULT_CLUSTER = "default-cluster";
 
     /**
+     * build service name for config， format: interface[:uniqueId]:protocol
+     * 1. here we didn't use protocol like other registry with symbol '@' but ':'
+     * because the limit of Nacos Service Name can only have these characters: '0-9a-zA-Z.:_-',
+     * and ':' won't corrupt with uniqueId because it'll always at the end of the service name.
+     * 2. here we didn't use ConfigUniqueNameGenerator.getUniqueName()
+     * because I think this method is only for old version compatible,
+     * and here we needn't version here anymore.
+     * @param config   producer config or consumer config
+     * @param protocol protocol for config
+     * @return unique service name
+     */
+    static String buildServiceName(AbstractInterfaceConfig config, String protocol){
+        if(RpcConstants.PROTOCOL_TYPE_BOLT.equals(protocol)
+                || RpcConstants.PROTOCOL_TYPE_TR.equals(protocol)){
+            return ConfigUniqueNameGenerator.getServiceName(config) + ":DEFAULT";
+        } else {
+            return ConfigUniqueNameGenerator.getServiceName(config) + ":" + protocol;
+        }
+    }
+
+    /**
      * Convert provider to instances list.
      *
      * @param providerConfig the provider config 
@@ -53,9 +76,10 @@ class NacosRegistryHelper {
         if (servers != null && !servers.isEmpty()) {
             List<Instance> instances = new ArrayList<Instance>();
             for (ServerConfig server : servers) {
+                String serviceName = buildServiceName(providerConfig, server.getProtocol());
                 Instance instance = new Instance();
                 instance.setClusterName(DEFAULT_CLUSTER);
-                instance.setServiceName(providerConfig.getInterfaceId());
+                instance.setServiceName(serviceName);
 
                 // set host port
                 String host = server.getVirtualHost();

--- a/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryProviderObserver.java
+++ b/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryProviderObserver.java
@@ -78,7 +78,8 @@ public class NacosRegistryProviderObserver {
     void updateProviders(ConsumerConfig config, List<Instance> instances) {
         if (LOGGER.isInfoEnabled(config.getAppName())) {
             LOGGER.infoWithApp(config.getAppName(),
-                "Receive update provider: serviceName={}, size={}, data={}", NacosRegistryHelper.buildServiceName(config, config.getProtocol()), instances.size(),
+                "Receive update provider: serviceName={}, size={}, data={}",
+                NacosRegistryHelper.buildServiceName(config, config.getProtocol()), instances.size(),
                 instances);
         }
         List<ProviderInfoListener> providerInfoListeners = providerListenerMap.get(config);

--- a/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryProviderObserver.java
+++ b/extension-impl/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryProviderObserver.java
@@ -78,7 +78,7 @@ public class NacosRegistryProviderObserver {
     void updateProviders(ConsumerConfig config, List<Instance> instances) {
         if (LOGGER.isInfoEnabled(config.getAppName())) {
             LOGGER.infoWithApp(config.getAppName(),
-                "Receive update provider: serviceName={}, size={}, data={}", config.getInterfaceId(), instances.size(),
+                "Receive update provider: serviceName={}, size={}, data={}", NacosRegistryHelper.buildServiceName(config, config.getProtocol()), instances.size(),
                 instances);
         }
         List<ProviderInfoListener> providerInfoListeners = providerListenerMap.get(config);

--- a/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelperTest.java
+++ b/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelperTest.java
@@ -108,22 +108,22 @@ public class NacosRegistryHelperTest {
     }
 
     @Test
-    public void buildServiceName(){
+    public void buildServiceName() {
         ServerConfig serverConfig = new ServerConfig()
-                .setProtocol("bolt")
-                .setHost("0.0.0.0")
-                .setPort(12200);
+            .setProtocol("bolt")
+            .setHost("0.0.0.0")
+            .setPort(12200);
 
         ProviderConfig<?> provider = new ProviderConfig();
         provider.setInterfaceId("com.alipay.xxx.TestService")
-                .setApplication(new ApplicationConfig().setAppName("test-server"))
-                .setUniqueId("nacos-test")
-                .setProxy("javassist")
-                .setRegister(true)
-                .setSerialization("hessian2")
-                .setServer(serverConfig)
-                .setWeight(222)
-                .setTimeout(3000);
+            .setApplication(new ApplicationConfig().setAppName("test-server"))
+            .setUniqueId("nacos-test")
+            .setProxy("javassist")
+            .setRegister(true)
+            .setSerialization("hessian2")
+            .setServer(serverConfig)
+            .setWeight(222)
+            .setTimeout(3000);
         String serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_BOLT);
         assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:DEFAULT");
 
@@ -131,9 +131,9 @@ public class NacosRegistryHelperTest {
         assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:DEFAULT");
 
         serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_GRPC);
-        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:"+ RpcConstants.PROTOCOL_TYPE_GRPC);
+        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:" + RpcConstants.PROTOCOL_TYPE_GRPC);
 
         serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_REST);
-        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:"+ RpcConstants.PROTOCOL_TYPE_REST);
+        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:" + RpcConstants.PROTOCOL_TYPE_REST);
     }
 }

--- a/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelperTest.java
+++ b/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryHelperTest.java
@@ -75,6 +75,7 @@ public class NacosRegistryHelperTest {
             Integer.parseInt(instance.getMetadata().get(RpcConstants.CONFIG_KEY_TIMEOUT)));
         assertEquals(provider.getSerialization(), instance.getMetadata().get(RpcConstants.CONFIG_KEY_SERIALIZATION));
         assertEquals(provider.getAppName(), instance.getMetadata().get(RpcConstants.CONFIG_KEY_APP_NAME));
+        assertEquals("com.alipay.xxx.TestService:nacos-test:DEFAULT", instance.getServiceName());
     }
 
     @Test
@@ -104,5 +105,35 @@ public class NacosRegistryHelperTest {
         providerInfos = NacosRegistryHelper.convertInstancesToProviders(Lists.newArrayList(instance));
         providerInfo = providerInfos.get(0);
         assertEquals(RpcConstants.PROTOCOL_TYPE_REST, providerInfo.getProtocolType());
+    }
+
+    @Test
+    public void buildServiceName(){
+        ServerConfig serverConfig = new ServerConfig()
+                .setProtocol("bolt")
+                .setHost("0.0.0.0")
+                .setPort(12200);
+
+        ProviderConfig<?> provider = new ProviderConfig();
+        provider.setInterfaceId("com.alipay.xxx.TestService")
+                .setApplication(new ApplicationConfig().setAppName("test-server"))
+                .setUniqueId("nacos-test")
+                .setProxy("javassist")
+                .setRegister(true)
+                .setSerialization("hessian2")
+                .setServer(serverConfig)
+                .setWeight(222)
+                .setTimeout(3000);
+        String serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_BOLT);
+        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:DEFAULT");
+
+        serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_TR);
+        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:DEFAULT");
+
+        serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_GRPC);
+        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:"+ RpcConstants.PROTOCOL_TYPE_GRPC);
+
+        serviceName = NacosRegistryHelper.buildServiceName(provider, RpcConstants.PROTOCOL_TYPE_REST);
+        assertEquals(serviceName, "com.alipay.xxx.TestService:nacos-test:"+ RpcConstants.PROTOCOL_TYPE_REST);
     }
 }


### PR DESCRIPTION
…will compose with interfaceId and uniqueId and protocol. (#612)

### Motivation:

增强了Nacos服务注册客户端注册ServiceName的信息, 现在ServiceName由InterfaceName, Identifier以及Protocol共同组成. 新的ServiceName支持相同接口不同实现以及相同接口不同服务协议的注册消费支持.

### Modification:

在NacosRegistryHelper中增加了根据生产或消费配置生成对外ServiceName的方法. NacosRegistry所有注册和消费服务时提交的ServiceName统一使用NacosRegistryHelper中的工具方法进行操作

### Result:

Fixes #612 . 

