### PR TITLE
Fix travis ci install jdk failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 #.travis.yml
 language: java
 
+dist: trusty
+
 jdk:
 - oraclejdk8
 


### PR DESCRIPTION
### Motivation:

Fix travis ci install jdk failed

### Modification:

Change travis ci dist to trusty.

### Result:

Fixes #668 

