### PR TITLE
Change method name 'now' to 'getCurrentTime'

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
@@ -512,25 +512,25 @@ public abstract class AbstractCluster extends Cluster {
             SofaResponse response = null;
             // 同步调用
             if (RpcConstants.INVOKER_TYPE_SYNC.equals(invokeType)) {
-                long start = RpcRuntimeContext.now();
+                long start = RpcRuntimeContext.getCurrentTime();
                 try {
                     response = transport.syncSend(request, timeout);
                 } finally {
                     if (RpcInternalContext.isAttachmentEnable()) {
-                        long elapsed = RpcRuntimeContext.now() - start;
+                        long elapsed = RpcRuntimeContext.getCurrentTime() - start;
                         context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, elapsed);
                     }
                 }
             }
             // 单向调用
             else if (RpcConstants.INVOKER_TYPE_ONEWAY.equals(invokeType)) {
-                long start = RpcRuntimeContext.now();
+                long start = RpcRuntimeContext.getCurrentTime();
                 try {
                     transport.oneWaySend(request, timeout);
                     response = buildEmptyResponse(request);
                 } finally {
                     if (RpcInternalContext.isAttachmentEnable()) {
-                        long elapsed = RpcRuntimeContext.now() - start;
+                        long elapsed = RpcRuntimeContext.getCurrentTime() - start;
                         context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, elapsed);
                     }
                 }
@@ -547,7 +547,7 @@ public abstract class AbstractCluster extends Cluster {
                     }
                 }
                 // 记录发送开始时间
-                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.now());
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.getCurrentTime());
                 // 开始调用
                 transport.asyncSend(request, timeout);
                 response = buildEmptyResponse(request);
@@ -555,7 +555,7 @@ public abstract class AbstractCluster extends Cluster {
             // Future调用
             else if (RpcConstants.INVOKER_TYPE_FUTURE.equals(invokeType)) {
                 // 记录发送开始时间
-                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.now());
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.getCurrentTime());
                 // 开始调用
                 ResponseFuture future = transport.asyncSend(request, timeout);
                 // 放入线程上下文
@@ -668,12 +668,12 @@ public abstract class AbstractCluster extends Cluster {
             int count = countOfInvoke.get();
             final int timeout = consumerConfig.getDisconnectTimeout(); // 等待结果超时时间
             if (count > 0) { // 有正在调用的请求
-                long start = RpcRuntimeContext.now();
+                long start = RpcRuntimeContext.getCurrentTime();
                 if (LOGGER.isWarnEnabled()) {
                     LOGGER.warn("There are {} outstanding call in client, will close transports util return",
                         count);
                 }
-                while (countOfInvoke.get() > 0 && RpcRuntimeContext.now() - start < timeout) { // 等待返回结果
+                while (countOfInvoke.get() > 0 && RpcRuntimeContext.getCurrentTime() - start < timeout) { // 等待返回结果
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException ignore) {

--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/AbstractIdConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/AbstractIdConfig.java
@@ -37,7 +37,7 @@ public abstract class AbstractIdConfig<S extends AbstractIdConfig> implements Se
     private final static AtomicInteger ID_GENERATOR     = new AtomicInteger(0);
 
     static {
-        RpcRuntimeContext.now();
+        RpcRuntimeContext.getCurrentTime();
     }
 
     /**

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcRuntimeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcRuntimeContext.java
@@ -71,7 +71,7 @@ public class RpcRuntimeContext {
     /**
      * 当前应用启动时间（用这个类加载时间为准）
      */
-    public static final long                                  START_TIME                = now();
+    public static final long                                  START_TIME                = getCurrentTime();
 
     /**
      * 发布的服务配置
@@ -198,7 +198,7 @@ public class RpcRuntimeContext {
      *
      * @return 当前时间
      */
-    public static long now() {
+    public static long getCurrentTime() {
         return System.currentTimeMillis();
     }
 

--- a/core/api/src/main/java/com/alipay/sofa/rpc/filter/ProviderInvoker.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/filter/ProviderInvoker.java
@@ -89,7 +89,7 @@ public class ProviderInvoker<T> extends FilterInvoker {
         }*/
 
         SofaResponse sofaResponse = new SofaResponse();
-        long startTime = RpcRuntimeContext.now();
+        long startTime = RpcRuntimeContext.getCurrentTime();
         try {
             // 反射 真正调用业务代码
             Method method = request.getMethod();
@@ -112,7 +112,7 @@ public class ProviderInvoker<T> extends FilterInvoker {
             sofaResponse.setAppResponse(e.getCause());
         } finally {
             if (RpcInternalContext.isAttachmentEnable()) {
-                long endTime = RpcRuntimeContext.now();
+                long endTime = RpcRuntimeContext.getCurrentTime();
                 RpcInternalContext.getContext().setAttachment(RpcConstants.INTERNAL_KEY_IMPL_ELAPSE,
                     endTime - startTime);
             }

--- a/core/api/src/main/java/com/alipay/sofa/rpc/message/AbstractResponseFuture.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/message/AbstractResponseFuture.java
@@ -48,7 +48,7 @@ public abstract class AbstractResponseFuture<V> implements ResponseFuture<V> {
     /**
      * Future生成时间
      */
-    protected final long                         genTime            = RpcRuntimeContext.now();
+    protected final long                         genTime            = RpcRuntimeContext.getCurrentTime();
     /**
      * Future已发送时间
      */
@@ -296,7 +296,7 @@ public abstract class AbstractResponseFuture<V> implements ResponseFuture<V> {
      * 设置已发送时间
      */
     public void setSentTime() {
-        this.sentTime = RpcRuntimeContext.now();
+        this.sentTime = RpcRuntimeContext.getCurrentTime();
     }
 
     /**
@@ -304,7 +304,7 @@ public abstract class AbstractResponseFuture<V> implements ResponseFuture<V> {
      */
     protected void setDoneTime() {
         if (doneTime == 0L) {
-            doneTime = RpcRuntimeContext.now();
+            doneTime = RpcRuntimeContext.getCurrentTime();
         }
     }
 

--- a/core/api/src/main/java/com/alipay/sofa/rpc/transport/ClientTransportFactory.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/transport/ClientTransportFactory.java
@@ -60,13 +60,13 @@ public class ClientTransportFactory {
             if (disconnectTimeout > 0) { // 需要等待结束时间
                 int count = clientTransport.currentRequests();
                 if (count > 0) { // 有正在调用的请求
-                    long start = RpcRuntimeContext.now();
+                    long start = RpcRuntimeContext.getCurrentTime();
                     if (LOGGER.isInfoEnabled()) {
                         LOGGER.info("There are {} outstanding call in transport, wait {}ms to end",
                             count, disconnectTimeout);
                     }
                     while (clientTransport.currentRequests() > 0
-                        && RpcRuntimeContext.now() - start < disconnectTimeout) { // 等待返回结果
+                        && RpcRuntimeContext.getCurrentTime() - start < disconnectTimeout) { // 等待返回结果
                         try {
                             Thread.sleep(10);
                         } catch (InterruptedException ignore) {

--- a/extension-impl/extension-common/src/main/java/com/alipay/sofa/rpc/registry/utils/RegistryUtils.java
+++ b/extension-impl/extension-common/src/main/java/com/alipay/sofa/rpc/registry/utils/RegistryUtils.java
@@ -103,7 +103,7 @@ public class RegistryUtils {
         metaData.put(RpcConstants.CONFIG_KEY_DYNAMIC, String.valueOf(providerConfig.isDynamic()));
         metaData.put(ProviderInfoAttrs.ATTR_WEIGHT, String.valueOf(providerConfig.getWeight()));
         metaData.put(RpcConstants.CONFIG_KEY_ACCEPTS, String.valueOf(server.getAccepts()));
-        metaData.put(ProviderInfoAttrs.ATTR_START_TIME, String.valueOf(RpcRuntimeContext.now()));
+        metaData.put(ProviderInfoAttrs.ATTR_START_TIME, String.valueOf(RpcRuntimeContext.getCurrentTime()));
         metaData.put(RpcConstants.CONFIG_KEY_APP_NAME, providerConfig.getAppName());
         metaData.put(RpcConstants.CONFIG_KEY_SERIALIZATION, providerConfig.getSerialization());
         metaData.put(RpcConstants.CONFIG_KEY_PROTOCOL, server.getProtocol());
@@ -139,7 +139,7 @@ public class RegistryUtils {
             .append(getKeyPairs(RpcConstants.CONFIG_KEY_APP_NAME, consumerConfig.getAppName()))
             .append(getKeyPairs(RpcConstants.CONFIG_KEY_SERIALIZATION,
                 consumerConfig.getSerialization()))
-            .append(getKeyPairs(ProviderInfoAttrs.ATTR_START_TIME, RpcRuntimeContext.now()))
+            .append(getKeyPairs(ProviderInfoAttrs.ATTR_START_TIME, RpcRuntimeContext.getCurrentTime()))
             .append(convertMap2Pair(consumerConfig.getParameters()));
         addCommonAttrs(sb);
         return sb.toString();

--- a/extension-impl/registry-local/src/main/java/com/alipay/sofa/rpc/registry/local/LocalRegistryHelper.java
+++ b/extension-impl/registry-local/src/main/java/com/alipay/sofa/rpc/registry/local/LocalRegistryHelper.java
@@ -138,7 +138,7 @@ public class LocalRegistryHelper {
             }
             // 锁住超过10秒，删掉
             if (lockFile.exists()) {
-                if ((RpcRuntimeContext.now() - lockFile.lastModified()) > 10000) {
+                if ((RpcRuntimeContext.getCurrentTime() - lockFile.lastModified()) > 10000) {
                     boolean ret = lockFile.delete();
                     if (LOGGER.isWarnEnabled()) {
                         LOGGER.warn("Other process is locking over 60s, force release : {}", ret);
@@ -195,7 +195,7 @@ public class LocalRegistryHelper {
                     }
                 }
                 LOGGER.info("Write backup file to {}", regFile.getAbsolutePath());
-                regFile.setLastModified(RpcRuntimeContext.now());
+                regFile.setLastModified(RpcRuntimeContext.getCurrentTime());
             }
         } catch (Exception e) {
             LOGGER.error("Backup registry file error !", e);

--- a/extension-impl/registry-sofa/src/main/java/com/alipay/sofa/rpc/registry/sofa/SofaRegistryHelper.java
+++ b/extension-impl/registry-sofa/src/main/java/com/alipay/sofa/rpc/registry/sofa/SofaRegistryHelper.java
@@ -248,7 +248,7 @@ public class SofaRegistryHelper {
      * @param sb 属性
      */
     private static void addCommonAttrs(StringBuilder sb) {
-        sb.append(getKeyPairs(ATTR_START_TIME, RpcRuntimeContext.now()));
+        sb.append(getKeyPairs(ATTR_START_TIME, RpcRuntimeContext.getCurrentTime()));
         //sb.append(getKeyPairs("pid", RpcRuntimeContext.PID));
         //sb.append(getKeyPairs("language", "java"));
         //sb.append(getKeyPairs("appPath", RpcRuntimeContext.get(RpcRuntimeContext.KEY_APPAPTH)));

--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallback.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallback.java
@@ -66,7 +66,7 @@ public abstract class AbstractInvokeCallback implements InvokeCallback {
         if (context != null) {
             Long startTime = (Long) context.removeAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME);
             if (startTime != null) {
-                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, RpcRuntimeContext.now() - startTime);
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, RpcRuntimeContext.getCurrentTime() - startTime);
             }
         }
     }

--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/server/bolt/BoltServer.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/server/bolt/BoltServer.java
@@ -207,13 +207,13 @@ public class BoltServer implements Server {
             AtomicInteger count = boltServerProcessor.processingCount;
             // 有正在执行的请求 或者 队列里有请求
             if (count.get() > 0 || bizThreadPool.getQueue().size() > 0) {
-                long start = RpcRuntimeContext.now();
+                long start = RpcRuntimeContext.getCurrentTime();
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("There are {} call in processing and {} call in queue, wait {} ms to end",
                         count, bizThreadPool.getQueue().size(), stopTimeout);
                 }
                 while ((count.get() > 0 || bizThreadPool.getQueue().size() > 0)
-                    && RpcRuntimeContext.now() - start < stopTimeout) { // 等待返回结果
+                    && RpcRuntimeContext.getCurrentTime() - start < stopTimeout) { // 等待返回结果
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException ignore) {

--- a/extension-impl/remoting-bolt/src/test/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallbackTest.java
+++ b/extension-impl/remoting-bolt/src/test/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallbackTest.java
@@ -42,7 +42,7 @@ public class AbstractInvokeCallbackTest {
         elapse = (Long) context.getAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE);
         Assert.assertNull(elapse);
 
-        context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.now() - 1000);
+        context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.getCurrentTime() - 1000);
         invokerCallback.recordClientElapseTime();
         elapse = (Long) context.getAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE);
         Assert.assertNotNull(elapse);

--- a/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttpClientHandler.java
+++ b/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttpClientHandler.java
@@ -88,7 +88,7 @@ public abstract class AbstractHttpClientHandler implements ClientHandler {
         if (context != null) {
             Long startTime = (Long) context.removeAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME);
             if (startTime != null) {
-                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, RpcRuntimeContext.now() - startTime);
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, RpcRuntimeContext.getCurrentTime() - startTime);
             }
         }
     }

--- a/extension-impl/tracer-opentracing-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/TraceResponseFilter.java
+++ b/extension-impl/tracer-opentracing-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/TraceResponseFilter.java
@@ -45,7 +45,7 @@ public class TraceResponseFilter implements ContainerResponseFilter {
             context.setAttachment(RpcConstants.INTERNAL_KEY_RESP_SIZE, responseContext.getLength());
             Long startTime = (Long) context.removeAttachment(RpcConstants.INTERNAL_KEY_SERVER_RECEIVE_TIME);
             if (startTime != null) {
-                context.setAttachment(RpcConstants.INTERNAL_KEY_IMPL_ELAPSE, RpcRuntimeContext.now() - startTime);
+                context.setAttachment(RpcConstants.INTERNAL_KEY_IMPL_ELAPSE, RpcRuntimeContext.getCurrentTime() - startTime);
             }
         }
     }

--- a/extension-impl/tracer-opentracing-resteasy/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/RestTracerAdapter.java
+++ b/extension-impl/tracer-opentracing-resteasy/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/RestTracerAdapter.java
@@ -133,7 +133,7 @@ public class RestTracerAdapter {
             if (serverSpan != null) {
                 RpcInternalContext context = RpcInternalContext.getContext();
 
-                context.setAttachment(RpcConstants.INTERNAL_KEY_SERVER_RECEIVE_TIME, RpcRuntimeContext.now());
+                context.setAttachment(RpcConstants.INTERNAL_KEY_SERVER_RECEIVE_TIME, RpcRuntimeContext.getCurrentTime());
 
                 SofaResourceMethodInvoker resourceMethodInvoker = (SofaResourceMethodInvoker)
                         ((PostMatchContainerRequestContext) requestContext)

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/registry/MockTestRegistry.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/registry/MockTestRegistry.java
@@ -255,7 +255,7 @@ public class MockTestRegistry extends Registry {
                 sb.append(getKeyPairs(key, value));
             }
         }
-        sb.append(getKeyPairs(ATTR_START_TIME, RpcRuntimeContext.now()));
+        sb.append(getKeyPairs(ATTR_START_TIME, RpcRuntimeContext.getCurrentTime()));
         return sb.toString();
     }
 


### PR DESCRIPTION
This class is used to represent   RpcRuntimeContext .  This method named 'now' is to get current time. Thus, the method name 'getCurrentTime' is more intuitive than 'now'.