### PR TITLE
Fix generic invoke method name

### DIFF
--- a/extension-impl/tracer-opentracing/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/RpcSofaTracer.java
+++ b/extension-impl/tracer-opentracing/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/RpcSofaTracer.java
@@ -268,6 +268,9 @@ public class RpcSofaTracer extends Tracer {
                 clientSpan.setTag(RpcSpanTags.LOCAL_IP, NetUtils.toIpString(address));
                 clientSpan.setTag(RpcSpanTags.LOCAL_PORT, address.getPort());
             }
+
+            //adjust for generic invoke
+            clientSpan.setTag(RpcSpanTags.METHOD, request.getMethodName());
         }
 
         Throwable throwableShow = exceptionThrow;


### PR DESCRIPTION
### Motivation:

Explain the context, and why you're making that change.
To make others understand what is the problem you're trying to solve.

### Modification:

{"timestamp":"2019-09-19 08:16:05.659","tracerId":"1e27a7d51568852165656101897688","spanId":"0","span.kind":"client","local.app":"generic-client","protocol":"bolt","service":"com.alipay.sofa.rpc.invoke.generic.TestGenericService:1.0","method":"echoObj","current.thread.name":"main","invoke.type":"sync","router.record":"DIRECT","remote.app":"generic-server","remote.ip":"127.0.0.1:22222","local.client.ip":"127.0.0.1","result.code":"00","req.serialize.time":"0","resp.deserialize.time":"3","resp.size":"225","req.size":"1384","client.conn.time":"0","client.elapse.time":"3","local.client.port":"22222","baggage":""}
### Result:

Fixes #https://github.com/sofastack/sofa-rpc/issues/767

If there is no issue then describe the changes introduced by this PR.