### PR TITLE
Upgrade jackson version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,8 +29,8 @@
         <hessian.version>3.3.6</hessian.version>
         <thrift.version>0.9.2</thrift.version>
         <protobuf.version>3.1.0</protobuf.version>
-        <jackson.version>2.9.9</jackson.version>
-        <jackson.databind.version>2.9.9.1</jackson.databind.version>
+        <jackson.version>2.9.10</jackson.version>
+        <jackson.databind.version>2.9.10</jackson.databind.version>
         <msgpack.version>0.6.11</msgpack.version>
         <protostuff.version>1.5.9</protostuff.version>
 


### PR DESCRIPTION
### Motivation:
jackson security issue:
https://nvd.nist.gov/vuln/detail/CVE-2019-16335
https://nvd.nist.gov/vuln/detail/CVE-2019-14540

### Modification:

upgrade jackson version to 2.9.10

