### PR TITLE
feat (metrics): Provides simple integration of micrometers.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -258,6 +258,11 @@
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-metrics-micrometer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-rpc-doc-swagger</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -430,6 +435,7 @@
                                     <include>com.alipay.sofa:sofa-rpc-fault-hystrix</include>
                                     <include>com.alipay.sofa:sofa-rpc-log-common-tools</include>
                                     <include>com.alipay.sofa:sofa-rpc-metrics-lookout</include>
+                                    <include>com.alipay.sofa:sofa-rpc-metrics-micrometer</include>
                                     <include>com.alipay.sofa:sofa-rpc-registry-consul</include>
                                     <include>com.alipay.sofa:sofa-rpc-registry-local</include>
                                     <include>com.alipay.sofa:sofa-rpc-registry-zk</include>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -500,12 +500,6 @@
                 <artifactId>jetty-alpn-openjdk8-client</artifactId>
                 <version>9.4.8.v20171121</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.25.Final</version>
-                <classifier>${os.detected.classifier}</classifier>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -451,6 +451,13 @@
                 <artifactId>lookout-core</artifactId>
                 <version>${lookout.version}</version>
             </dependency>
+            <!-- micrometer -->
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>1.3.5</version>
+                <scope>provided</scope>
+            </dependency>
             <!-- Test libs -->
             <dependency>
                 <groupId>junit</groupId>

--- a/extension-impl/metrics-micrometer/pom.xml
+++ b/extension-impl/metrics-micrometer/pom.xml
@@ -30,7 +30,7 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>1.3.2</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extension-impl/metrics-micrometer/pom.xml
+++ b/extension-impl/metrics-micrometer/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.alipay.sofa</groupId>
+        <artifactId>sofa-rpc-extension-impl</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>sofa-rpc-metrics-micrometer</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-extension-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-log-common-tools</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <!-- micrometer -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/**</include>
+                </includes>
+            </resource>
+        </resources>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/**</include>
+                </includes>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>${module.install.skip}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>${module.deploy.skip}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipTests}</skipTests>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <forkMode>once</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extension-impl/metrics-micrometer/pom.xml
+++ b/extension-impl/metrics-micrometer/pom.xml
@@ -30,7 +30,7 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>1.3.2</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/extension-impl/metrics-micrometer/pom.xml
+++ b/extension-impl/metrics-micrometer/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.3.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extension-impl/metrics-micrometer/src/main/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetrics.java
+++ b/extension-impl/metrics-micrometer/src/main/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetrics.java
@@ -1,0 +1,308 @@
+package com.alipay.sofa.rpc.metrics.micrometer;
+
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.context.RpcInternalContext;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.event.ClientEndInvokeEvent;
+import com.alipay.sofa.rpc.event.ConsumerSubEvent;
+import com.alipay.sofa.rpc.event.Event;
+import com.alipay.sofa.rpc.event.EventBus;
+import com.alipay.sofa.rpc.event.ProviderPubEvent;
+import com.alipay.sofa.rpc.event.ServerSendEvent;
+import com.alipay.sofa.rpc.event.ServerStartedEvent;
+import com.alipay.sofa.rpc.event.ServerStoppedEvent;
+import com.alipay.sofa.rpc.event.Subscriber;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * @author hujia
+ * @date 2020/3/2
+ */
+public class SofaRpcMetrics extends Subscriber implements MeterBinder, AutoCloseable {
+
+    private final AtomicReference<MeterRegistry> initialed = new AtomicReference<>();
+
+    private final Function<Tags, Timer> clientTotal = tags -> Timer.builder("sofa.client.total")
+        .tags(tags)
+        .register(initialed.get());
+    private Function<Tags, Timer> clientFail = tags -> Timer.builder("sofa.client.fail")
+        .tags(tags)
+        .register(initialed.get());
+    private final Function<Tags, Timer> serverTotal = tags -> Timer.builder("sofa.server.total")
+        .tags(tags)
+        .register(initialed.get());
+    private final Function<Tags, Timer> serverFail = tags -> Timer.builder("sofa.server.fail")
+        .tags(tags)
+        .register(initialed.get());
+    private final Function<Tags, DistributionSummary> requestSize = tags -> DistributionSummary.builder("sofa.request.size")
+        .tags(tags)
+        .baseUnit(BaseUnits.BYTES)
+        .register(initialed.get());
+    private final Function<Tags, DistributionSummary> responseSize = tags -> DistributionSummary.builder("sofa.response.size")
+        .tags(tags)
+        .baseUnit(BaseUnits.BYTES)
+        .register(initialed.get());
+    private Counter provider;
+    private Counter consumer;
+
+    private final Tags common;
+
+    private final AtomicReference<ServerConfig> serverConfig = new AtomicReference<>();
+    private final AtomicReference<ThreadPoolExecutor> executor = new AtomicReference<>();
+
+    public SofaRpcMetrics() {
+        this(Collections.emptyList());
+    }
+
+    public SofaRpcMetrics(Iterable<Tag> common) {
+        this.common = Tags.of(common);
+        register();
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder("sofa.threadpool.config.core", () -> Optional.of(serverConfig)
+            .map(AtomicReference::get)
+            .map(ServerConfig::getCoreThreads)
+            .orElse(0))
+            .tags(common)
+            .baseUnit(BaseUnits.THREADS)
+            .register(registry);
+        Gauge.builder("sofa.threadpool.config.max", () -> Optional.of(serverConfig)
+            .map(AtomicReference::get)
+            .map(ServerConfig::getMaxThreads)
+            .orElse(0))
+            .tags(common)
+            .baseUnit(BaseUnits.THREADS)
+            .register(registry);
+        Gauge.builder("sofa.threadpool.config.queue", () -> Optional.of(serverConfig)
+            .map(AtomicReference::get)
+            .map(ServerConfig::getQueues)
+            .orElse(0))
+            .tags(common)
+            .baseUnit(BaseUnits.TASKS)
+            .register(registry);
+        Gauge.builder("sofa.threadpool.active", () -> Optional.of(executor)
+            .map(AtomicReference::get)
+            .map(ThreadPoolExecutor::getActiveCount)
+            .orElse(0))
+            .tags(common)
+            .baseUnit(BaseUnits.THREADS)
+            .register(registry);
+        Gauge.builder("sofa.threadpool.idle", () -> Optional.of(executor)
+            .map(AtomicReference::get)
+            .map(e -> e.getPoolSize() - e.getActiveCount())
+            .orElse(0))
+            .tags(common)
+            .baseUnit(BaseUnits.THREADS)
+            .register(registry);
+        Gauge.builder("sofa.threadpool.queue.size", () -> Optional.of(executor)
+            .map(AtomicReference::get)
+            .map(ThreadPoolExecutor::getQueue)
+            .map(Collection::size)
+            .orElse(0))
+            .tags(common)
+            .baseUnit(BaseUnits.TASKS)
+            .register(registry);
+        provider = Counter.builder("sofa.provider")
+            .tags(common)
+            .register(registry);
+        consumer = Counter.builder("sofa.consumer")
+            .tags(common)
+            .register(registry);
+
+        initialed.set(registry);
+    }
+
+    private void register() {
+        EventBus.register(ClientEndInvokeEvent.class, this);
+        EventBus.register(ServerSendEvent.class, this);
+        EventBus.register(ServerStartedEvent.class, this);
+        EventBus.register(ServerStoppedEvent.class, this);
+        EventBus.register(ProviderPubEvent.class, this);
+        EventBus.register(ConsumerSubEvent.class, this);
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        if (initialed.get() != null) {
+            if (event instanceof ClientEndInvokeEvent) {
+                onEvent((ClientEndInvokeEvent) event);
+            } else if (event instanceof ServerSendEvent) {
+                onEvent((ServerSendEvent) event);
+            } else if (event instanceof ServerStartedEvent) {
+                onEvent((ServerStartedEvent) event);
+            } else if (event instanceof ServerStoppedEvent) {
+                onEvent((ServerStoppedEvent) event);
+            } else if (event instanceof ProviderPubEvent) {
+                onEvent((ProviderPubEvent) event);
+            } else if (event instanceof ConsumerSubEvent) {
+                onEvent((ConsumerSubEvent) event);
+            } else {
+                throw new IllegalArgumentException("unexpected event: " + event);
+            }
+        }
+    }
+
+    private void onEvent(ClientEndInvokeEvent event) {
+        InvokeMeta meta = new InvokeMeta(
+            event.getRequest(),
+            event.getResponse(),
+            getLongAvoidNull(RpcInternalContext.getContext().getAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE))
+        );
+        RpcInternalContext context = RpcInternalContext.getContext();
+        Duration elapsed = meta.elapsed();
+        Tags tags = meta.tags(this.common);
+
+        clientTotal.apply(tags).record(elapsed);
+        if (!meta.success()) {
+            clientFail.apply(tags).record(elapsed);
+        }
+        requestSize.apply(tags).record(getLongAvoidNull(
+            context.getAttachment(RpcConstants.INTERNAL_KEY_REQ_SIZE)));
+        responseSize.apply(tags).record(getLongAvoidNull(
+            context.getAttachment(RpcConstants.INTERNAL_KEY_RESP_SIZE)));
+    }
+
+    private void onEvent(ServerSendEvent event) {
+        InvokeMeta meta = new InvokeMeta(
+            event.getRequest(),
+            event.getResponse(),
+            getLongAvoidNull(RpcInternalContext.getContext().getAttachment(RpcConstants.INTERNAL_KEY_IMPL_ELAPSE))
+        );
+        Duration elapsed = meta.elapsed();
+        Tags tags = meta.tags(this.common);
+        serverTotal.apply(tags).record(elapsed);
+        if (!meta.success()) {
+            serverFail.apply(tags).record(elapsed);
+        }
+    }
+
+    private void onEvent(ServerStartedEvent event) {
+        this.serverConfig.set(event.getServerConfig());
+        this.executor.set(event.getThreadPoolExecutor());
+    }
+
+    private void onEvent(ServerStoppedEvent event) {
+        serverConfig.set(null);
+        executor.set(null);
+    }
+
+    private void onEvent(ProviderPubEvent event) {
+        provider.increment();
+    }
+
+    private void onEvent(ConsumerSubEvent event) {
+        consumer.increment();
+    }
+
+    private static Long getLongAvoidNull(Object object) {
+        if (object == null) {
+            return null;
+        }
+
+        if (object instanceof Integer) {
+            return Long.parseLong(object.toString());
+        }
+
+        return (Long) object;
+    }
+
+    private static String getStringAvoidNull(Object object) {
+        if (object == null) {
+            return null;
+        }
+
+        return (String) object;
+
+    }
+
+    @Override
+    public void close() {
+        EventBus.unRegister(ClientEndInvokeEvent.class, this);
+        EventBus.unRegister(ServerSendEvent.class, this);
+        EventBus.unRegister(ServerStartedEvent.class, this);
+        EventBus.unRegister(ServerStoppedEvent.class, this);
+        EventBus.unRegister(ProviderPubEvent.class, this);
+        EventBus.unRegister(ConsumerSubEvent.class, this);
+    }
+
+    private static class InvokeMeta {
+
+        private final SofaRequest request;
+        private final SofaResponse response;
+        private final Duration elapsed;
+
+        private InvokeMeta(SofaRequest request, SofaResponse response, long elapsed) {
+            this.request = request;
+            this.response = response;
+            this.elapsed = Duration.ofMillis(elapsed);
+        }
+
+        public String app() {
+            return Optional.ofNullable(request.getTargetAppName()).orElse("");
+        }
+
+        public String callerApp() {
+            return Optional.ofNullable(getStringAvoidNull(
+                request.getRequestProp(RemotingConstants.HEAD_APP_NAME))).orElse("");
+        }
+
+        public String service() {
+            return Optional.ofNullable(request.getTargetServiceUniqueName()).orElse("");
+        }
+
+        public String method() {
+            return Optional.ofNullable(request.getMethodName()).orElse("");
+        }
+
+        public String protocol() {
+            return Optional.ofNullable(getStringAvoidNull(
+                request.getRequestProp(RemotingConstants.HEAD_PROTOCOL))).orElse("");
+        }
+
+        public String invokeType() {
+            return Optional.ofNullable(request.getInvokeType()).orElse("");
+        }
+
+        public Duration elapsed() {
+            return elapsed;
+        }
+
+        public boolean success() {
+            return response != null
+                && !response.isError()
+                && response.getErrorMsg() == null
+                && (!(response.getAppResponse() instanceof Throwable));
+        }
+
+        public Tags tags(Iterable<Tag> common) {
+            return Tags.of(common).and(
+                Tag.of("app", app()),
+                Tag.of("service", service()),
+                Tag.of("method", method()),
+                Tag.of("protocol", protocol()),
+                Tag.of("invoke_type", invokeType()),
+                Tag.of("caller_app", callerApp())
+            );
+        }
+    }
+}

--- a/extension-impl/metrics-micrometer/src/main/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetrics.java
+++ b/extension-impl/metrics-micrometer/src/main/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.rpc.metrics.micrometer;
 
 import com.alipay.sofa.rpc.common.RemotingConstants;

--- a/extension-impl/metrics-micrometer/src/main/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetrics.java
+++ b/extension-impl/metrics-micrometer/src/main/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetrics.java
@@ -59,7 +59,7 @@ public class SofaRpcMetrics extends Subscriber implements MeterBinder, AutoClose
     private final Function<Tags, Timer> clientTotal = tags -> Timer.builder("sofa.client.total")
         .tags(tags)
         .register(initialed.get());
-    private Function<Tags, Timer> clientFail = tags -> Timer.builder("sofa.client.fail")
+    private final Function<Tags, Timer> clientFail = tags -> Timer.builder("sofa.client.fail")
         .tags(tags)
         .register(initialed.get());
     private final Function<Tags, Timer> serverTotal = tags -> Timer.builder("sofa.server.total")

--- a/extension-impl/metrics-micrometer/src/test/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetricsTest.java
+++ b/extension-impl/metrics-micrometer/src/test/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetricsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.rpc.metrics.micrometer;
 
 import com.alipay.sofa.rpc.common.RemotingConstants;
@@ -68,8 +84,8 @@ public class SofaRpcMetricsTest {
         request.setInterfaceName(TestService.class.getName());
         request.setMethodName("echoStr");
         request.setMethod(TestService.class.getMethod("func"));
-        request.setMethodArgs(new Object[] { });
-        request.setMethodArgSigs(new String[] { });
+        request.setMethodArgs(new Object[] {});
+        request.setMethodArgSigs(new String[] {});
         request.setTargetServiceUniqueName(TestService.class.getName() + ":1.0");
         request.setTargetAppName("targetApp");
         request.setSerializeType((byte) 11);

--- a/extension-impl/metrics-micrometer/src/test/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetricsTest.java
+++ b/extension-impl/metrics-micrometer/src/test/java/com/alipay/sofa/rpc/metrics/micrometer/SofaRpcMetricsTest.java
@@ -1,0 +1,111 @@
+package com.alipay.sofa.rpc.metrics.micrometer;
+
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.common.utils.ReflectUtils;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.context.RpcInternalContext;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.core.invoke.SofaResponseCallback;
+import com.alipay.sofa.rpc.core.request.RequestBase;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.event.ClientEndInvokeEvent;
+import com.alipay.sofa.rpc.event.ConsumerSubEvent;
+import com.alipay.sofa.rpc.event.Event;
+import com.alipay.sofa.rpc.event.EventBus;
+import com.alipay.sofa.rpc.event.ProviderPubEvent;
+import com.alipay.sofa.rpc.event.ServerSendEvent;
+import com.alipay.sofa.rpc.event.ServerStartedEvent;
+import com.alipay.sofa.rpc.event.ServerStoppedEvent;
+import com.alipay.sofa.rpc.event.Subscriber;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SofaRpcMetricsTest {
+
+    @Test
+    public void testMicrometerMetrics() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try (SofaRpcMetrics metrics = new SofaRpcMetrics()) {
+            metrics.bindTo(registry);
+
+            Method handleEvent = EventBus.class.getDeclaredMethod(
+                "handleEvent", Subscriber.class, Event.class);
+            handleEvent.setAccessible(true);
+            SofaRequest request = buildRequest();
+            SofaResponse response = buildResponse();
+            RpcInternalContext.getContext()
+                .setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, 100)
+                .setAttachment(RpcConstants.INTERNAL_KEY_IMPL_ELAPSE, 10)
+                .setAttachment(RpcConstants.INTERNAL_KEY_REQ_SIZE, 3)
+                .setAttachment(RpcConstants.INTERNAL_KEY_RESP_SIZE, 4);
+
+            handleEvent.invoke(EventBus.class, metrics, new ClientEndInvokeEvent(request, response, null));
+            handleEvent.invoke(EventBus.class, metrics, new ServerSendEvent(request, response, null));
+            ServerConfig serverConfig = new ServerConfig();
+            handleEvent.invoke(EventBus.class, metrics, new ServerStartedEvent(serverConfig, new ThreadPoolExecutor(1, 1,
+                0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>())));
+            handleEvent.invoke(EventBus.class, metrics, new ServerStoppedEvent(serverConfig));
+            handleEvent.invoke(EventBus.class, metrics, new ProviderPubEvent(new ProviderConfig<>()));
+            handleEvent.invoke(EventBus.class, metrics, new ConsumerSubEvent(new ConsumerConfig<>()));
+
+            Assert.assertEquals(12, registry.getMeters().size());
+        }
+    }
+
+    private SofaRequest buildRequest() throws NoSuchMethodException {
+        SofaRequest request = new SofaRequest();
+        request.setInterfaceName(TestService.class.getName());
+        request.setMethodName("echoStr");
+        request.setMethod(TestService.class.getMethod("func"));
+        request.setMethodArgs(new Object[] { });
+        request.setMethodArgSigs(new String[] { });
+        request.setTargetServiceUniqueName(TestService.class.getName() + ":1.0");
+        request.setTargetAppName("targetApp");
+        request.setSerializeType((byte) 11);
+        request.setTimeout(1024);
+        request.setInvokeType(RpcConstants.INVOKER_TYPE_SYNC);
+        request.addRequestProp(RemotingConstants.HEAD_APP_NAME, "app");
+        request.addRequestProp(RemotingConstants.HEAD_PROTOCOL, "bolt");
+        request.setSofaResponseCallback(new SofaResponseCallback<String>() {
+            @Override
+            public void onAppResponse(Object appResponse, String methodName, RequestBase request) {
+
+            }
+
+            @Override
+            public void onAppException(Throwable throwable, String methodName, RequestBase request) {
+
+            }
+
+            @Override
+            public void onSofaException(SofaRpcException sofaException, String methodName, RequestBase request) {
+
+            }
+        });
+        return request;
+    }
+
+    private SofaResponse buildResponse() {
+        SofaResponse response = new SofaResponse();
+        response.setAppResponse("123");
+        return response;
+    }
+
+    private static class TestService {
+
+        public String func() {
+            return null;
+        }
+    }
+}

--- a/extension-impl/pom.xml
+++ b/extension-impl/pom.xml
@@ -29,6 +29,7 @@
         <module>fault-tolerance</module>
         <module>log-common-tools</module>
         <module>metrics-lookout</module>
+        <module>metrics-micrometer</module>
         <module>registry-consul</module>
         <module>registry-local</module>
         <module>registry-zk</module>

--- a/test/test-integration/pom.xml
+++ b/test/test-integration/pom.xml
@@ -134,6 +134,11 @@
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-metrics-micrometer</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-rpc-registry-local</artifactId>
             <version>${project.parent.version}</version>
         </dependency>


### PR DESCRIPTION
sofa-lookout提供了整套监控sofa-rpc的功能，但对广泛使用micrometer的项目来说并不友好，这个pr提供了一个可选的MteterBinder的实现，方便micrometer用户集成监控。

### Modification:

新增一个SofaRpcMetrics类，提供一组默认的监控指标。

### Result:

Fixes https://github.com/sofastack/sofa-lookout/issues/79
