### PR TITLE
# 892, The blacklist of the hessian serialization class can be extended when used.

### DIFF
--- a/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoader.java
+++ b/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoader.java
@@ -40,15 +40,24 @@ public class BlackListFileLoader {
 
     private static final Logger      LOGGER                    = LoggerFactory.getLogger(BlackListFileLoader.class);
 
-    public static final List<String> SOFA_SERIALIZE_BLACK_LIST = loadFile("/sofa-rpc/serialize_blacklist.txt");
+    public static final List<String> SOFA_SERIALIZE_BLACK_LIST = loadFile();
 
-    static List<String> loadFile(String path) {
+    static List<String> loadFile() {
         List<String> blackPrefixList = new ArrayList<String>();
         InputStream input = null;
+        InputStream extInput = null;
         try {
+            // 原始序列化黑名单类
+            String path = "/sofa-rpc/serialize_blacklist.txt";
             input = BlackListFileLoader.class.getResourceAsStream(path);
             if (input != null) {
                 readToList(input, "UTF-8", blackPrefixList);
+            }
+            // 应用额外增加的需要过滤的黑名单
+            path = "/META-INF/sofa-rpc/serialize_blacklist.txt";
+            extInput = BlackListFileLoader.class.getResourceAsStream(path);
+            if (extInput != null) {
+                readToList(extInput, "UTF-8", blackPrefixList);
             }
             String overStr = SofaConfigs.getStringValue(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE, "");
             if (StringUtils.isNotBlank(overStr)) {
@@ -63,6 +72,7 @@ public class BlackListFileLoader {
             }
         } finally {
             closeQuietly(input);
+            closeQuietly(extInput);
         }
         return blackPrefixList;
     }

--- a/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoader.java
+++ b/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoader.java
@@ -40,6 +40,11 @@ public class BlackListFileLoader {
 
     private static final Logger      LOGGER                    = LoggerFactory.getLogger(BlackListFileLoader.class);
 
+    // hessian主序列化黑名单类配置文件路径
+    private static final String BLACK_LISY_PATH = "/sofa-rpc/serialize_blacklist.txt";
+    // 应用额外增加的需要过滤的黑名单配置文件路径
+    private static final String EXT_BLACK_LISY_PATH = "/sofa-rpc/serialize_blacklist_ext.txt";
+    
     public static final List<String> SOFA_SERIALIZE_BLACK_LIST = loadFile();
 
     static List<String> loadFile() {
@@ -47,15 +52,13 @@ public class BlackListFileLoader {
         InputStream input = null;
         InputStream extInput = null;
         try {
-            // 原始序列化黑名单类
-            String path = "/sofa-rpc/serialize_blacklist.txt";
-            input = BlackListFileLoader.class.getResourceAsStream(path);
+            // 读主序列化黑名单
+            input = BlackListFileLoader.class.getResourceAsStream(BLACK_LISY_PATH);
             if (input != null) {
                 readToList(input, "UTF-8", blackPrefixList);
             }
-            // 应用额外增加的需要过滤的黑名单
-            path = "/META-INF/sofa-rpc/serialize_blacklist.txt";
-            extInput = BlackListFileLoader.class.getResourceAsStream(path);
+            // 读应用额外增加的需要过滤的黑名单
+            extInput = BlackListFileLoader.class.getResourceAsStream(EXT_BLACK_LISY_PATH);
             if (extInput != null) {
                 readToList(extInput, "UTF-8", blackPrefixList);
             }

--- a/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoaderTest.java
+++ b/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoaderTest.java
@@ -74,6 +74,49 @@ public class BlackListFileLoaderTest {
         }
         Assert.assertFalse(pass);
     }
+    
+    /* 
+     * 验证hessian扩展黑名单存在和被参数替换的情景
+     * 
+     */
+    @Test
+    public void testReplaceExtBalck() throws Exception {
+
+        List<String> blacks;
+
+        String s = System.getProperty(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE);
+        try {
+        	// 通过参数设置扩展的黑名单被移除名单列表
+            System.setProperty(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE, "-com.alipay.hessian.ext.BlackListExt");
+            blacks = BlackListFileLoader.loadFile();
+        } finally {
+            if (s != null) {
+            	// 恢复原始值
+                System.setProperty(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE, s);
+            }
+        }
+
+        NameBlackListFilter filter = new NameBlackListFilter(blacks);
+        boolean pass = true;   
+        String className = null;
+        // 验证扩展黑名单被移除名单
+        try {
+            className = filter.resolve("com.alipay.hessian.ext.BlackListExt");
+        } catch (Exception e) {
+            pass = false;
+        }
+        Assert.assertNotNull(className);
+        Assert.assertTrue(pass);
+        
+        //验证没有被替换的扩展黑名单在名单列表中
+        pass = true;
+        try {
+            className = filter.resolve("com.alipay.hessian.ext.BlackListExt2");
+        } catch (Exception e) {
+            pass = false;
+        }
+        Assert.assertFalse(pass);
+    }
 
     @Test
     public void overrideBlackList() {

--- a/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoaderTest.java
+++ b/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoaderTest.java
@@ -64,6 +64,15 @@ public class BlackListFileLoaderTest {
             pass = false;
         }
         Assert.assertFalse(pass);
+        
+        // 验证扩展黑名单
+        pass = true;
+        try {
+            className = filter.resolve("com.alipay.hessian.ext.BlackListExt");
+        } catch (Exception e) {
+            pass = false;
+        }
+        Assert.assertFalse(pass);
     }
 
     @Test

--- a/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoaderTest.java
+++ b/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoaderTest.java
@@ -39,7 +39,7 @@ public class BlackListFileLoaderTest {
         String s = System.getProperty(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE);
         try {
             System.setProperty(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE, "-java.net.Socket");
-            blacks = BlackListFileLoader.loadFile("/sofa-rpc/serialize_blacklist.txt");
+            blacks = BlackListFileLoader.loadFile();
         } finally {
             if (s != null) {
                 System.setProperty(SofaOptions.CONFIG_SERIALIZE_BLACKLIST_OVERRIDE, s);

--- a/extension-impl/codec-sofa-hessian/src/test/resources/sofa-rpc/serialize_blacklist_ext.txt
+++ b/extension-impl/codec-sofa-hessian/src/test/resources/sofa-rpc/serialize_blacklist_ext.txt
@@ -1,1 +1,2 @@
 com.alipay.hessian.ext.BlackListExt
+com.alipay.hessian.ext.BlackListExt2

--- a/extension-impl/codec-sofa-hessian/src/test/resources/sofa-rpc/serialize_blacklist_ext.txt
+++ b/extension-impl/codec-sofa-hessian/src/test/resources/sofa-rpc/serialize_blacklist_ext.txt
@@ -1,0 +1,1 @@
+com.alipay.hessian.ext.BlackListExt


### PR DESCRIPTION
### Motivation:

对hessian序列化类的黑名单增加使用时候可以扩展

### Modification:

多读一个应用自定义的配置文件

### Result:

Fixes #892. 
