### PR TITLE
fix(codec-jackson): fix json response error when response type is generic type.

### DIFF
--- a/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonHelper.java
+++ b/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonHelper.java
@@ -32,17 +32,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JacksonHelper {
 
-    private ObjectMapper                          mapper             = new ObjectMapper();
+    private ObjectMapper mapper = new ObjectMapper();
 
     /**
      * Request service and method cache {service+method:class}
      */
-    private ConcurrentHashMap<String, JavaType[]> requestClassCache  = new ConcurrentHashMap<String, JavaType[]>();
+    private ConcurrentHashMap<String, JavaType[]> requestClassCache = new ConcurrentHashMap<String, JavaType[]>();
 
     /**
      * Response service and method cache {service+method:class}
      */
-    private ConcurrentHashMap<String, Class>      responseClassCache = new ConcurrentHashMap<String, Class>();
+    private ConcurrentHashMap<String, JavaType> responseClassCache = new ConcurrentHashMap<String, JavaType>();
 
     /**
      * Fetch request class for cache according  service and method
@@ -71,10 +71,10 @@ public class JacksonHelper {
      * @param methodName method name
      * @return response class
      */
-    public Class getResClass(String service, String methodName) {
+    public JavaType getResClass(String service, String methodName) {
         String key = service + "#" + methodName;
-        Class reqClass = responseClassCache.get(key);
-        if (reqClass == null) {
+        JavaType reqType = responseClassCache.get(key);
+        if (reqType == null) {
             // 读取接口里的方法参数和返回值
             String interfaceClass = ConfigUniqueNameGenerator.getInterfaceName(service);
             Class clazz = ClassUtils.forName(interfaceClass, true);
@@ -102,30 +102,33 @@ public class JacksonHelper {
      * @param methodName method name
      */
     private void loadClassToCache(String key, Class clazz, String methodName) {
-        Method pbMethod = null;
+        Method jsonMethod = null;
         Method[] methods = clazz.getMethods();
         for (Method method : methods) {
             if (methodName.equals(method.getName())) {
-                pbMethod = method;
+                jsonMethod = method;
                 break;
             }
         }
-        if (pbMethod == null) {
-            throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_METHOD_NOT_FOUND, clazz.getName(),
-                methodName));
+        if (jsonMethod == null) {
+            throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_METHOD_NOT_FOUND, clazz.getName(), methodName));
         }
-        Type[] parameterTypes = pbMethod.getGenericParameterTypes();
+
+        // parse request types
+        Type[] parameterTypes = jsonMethod.getGenericParameterTypes();
         JavaType[] javaTypes = new JavaType[parameterTypes.length];
         for (int i = 0; i < parameterTypes.length; i++) {
             JavaType javaType = mapper.getTypeFactory().constructType(parameterTypes[i]);
             javaTypes[i] = javaType;
         }
-
         requestClassCache.put(key, javaTypes);
-        Class resClass = pbMethod.getReturnType();
-        if (resClass == void.class) {
+
+        // parse response types
+        Type resType = jsonMethod.getGenericReturnType();
+        if (resType == void.class) {
             throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_VOID_RETURN, "jackson", clazz.getName()));
         }
-        responseClassCache.put(key, resClass);
+        JavaType resJavaType = mapper.getTypeFactory().constructType(resType);
+        responseClassCache.put(key, resJavaType);
     }
 }

--- a/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonHelper.java
+++ b/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonHelper.java
@@ -32,17 +32,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JacksonHelper {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper                          mapper             = new ObjectMapper();
 
     /**
      * Request service and method cache {service+method:class}
      */
-    private ConcurrentHashMap<String, JavaType[]> requestClassCache = new ConcurrentHashMap<String, JavaType[]>();
+    private ConcurrentHashMap<String, JavaType[]> requestClassCache  = new ConcurrentHashMap<String, JavaType[]>();
 
     /**
      * Response service and method cache {service+method:class}
      */
-    private ConcurrentHashMap<String, JavaType> responseClassCache = new ConcurrentHashMap<String, JavaType>();
+    private ConcurrentHashMap<String, JavaType>   responseClassCache = new ConcurrentHashMap<String, JavaType>();
 
     /**
      * Fetch request class for cache according  service and method
@@ -111,7 +111,8 @@ public class JacksonHelper {
             }
         }
         if (jsonMethod == null) {
-            throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_METHOD_NOT_FOUND, clazz.getName(), methodName));
+            throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_METHOD_NOT_FOUND, clazz.getName(),
+                methodName));
         }
 
         // parse request types

--- a/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializer.java
+++ b/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializer.java
@@ -61,7 +61,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Extension(value = "json", code = 12)
 public class JacksonSerializer extends AbstractSerializer {
 
-    private ObjectMapper  mapper        = new ObjectMapper();
+    private ObjectMapper mapper = new ObjectMapper();
 
     private JacksonHelper jacksonHelper = new JacksonHelper();
 
@@ -83,7 +83,7 @@ public class JacksonSerializer extends AbstractSerializer {
     }
 
     protected AbstractByteBuf encodeSofaRequest(SofaRequest sofaRequest, Map<String, String> context)
-        throws SofaRpcException {
+            throws SofaRpcException {
         Object[] args = sofaRequest.getMethodArgs();
         if (args.length == 1) {
             return encode(args[0], context);
@@ -93,7 +93,7 @@ public class JacksonSerializer extends AbstractSerializer {
     }
 
     protected AbstractByteBuf encodeSofaResponse(SofaResponse sofaResponse, Map<String, String> context)
-        throws SofaRpcException {
+            throws SofaRpcException {
         AbstractByteBuf byteBuf;
         if (sofaResponse.isError()) {
             // rpc exception：error when body is illegal string
@@ -276,9 +276,14 @@ public class JacksonSerializer extends AbstractSerializer {
             sofaResponse.setErrorMsg(errorMessage);
         } else {
             // according interface and method name to find paramter types
-            Class responseClass = jacksonHelper.getResClass(targetService, methodName);
-            Object pbRes = decode(data, responseClass, head);
-            sofaResponse.setAppResponse(pbRes);
+            JavaType respType = jacksonHelper.getResClass(targetService, methodName);
+            Object result;
+            try {
+                result = mapper.readValue(data.array(), respType);
+            } catch (IOException e) {
+                throw buildDeserializeError(e.getMessage());
+            }
+            sofaResponse.setAppResponse(result);
         }
     }
 }

--- a/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializer.java
+++ b/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializer.java
@@ -61,7 +61,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Extension(value = "json", code = 12)
 public class JacksonSerializer extends AbstractSerializer {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private ObjectMapper  mapper        = new ObjectMapper();
 
     private JacksonHelper jacksonHelper = new JacksonHelper();
 
@@ -83,7 +83,7 @@ public class JacksonSerializer extends AbstractSerializer {
     }
 
     protected AbstractByteBuf encodeSofaRequest(SofaRequest sofaRequest, Map<String, String> context)
-            throws SofaRpcException {
+        throws SofaRpcException {
         Object[] args = sofaRequest.getMethodArgs();
         if (args.length == 1) {
             return encode(args[0], context);
@@ -93,7 +93,7 @@ public class JacksonSerializer extends AbstractSerializer {
     }
 
     protected AbstractByteBuf encodeSofaResponse(SofaResponse sofaResponse, Map<String, String> context)
-            throws SofaRpcException {
+        throws SofaRpcException {
         AbstractByteBuf byteBuf;
         if (sofaResponse.isError()) {
             // rpc exception：error when body is illegal string

--- a/codec/codec-jackson/src/test/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializerTest.java
+++ b/codec/codec-jackson/src/test/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializerTest.java
@@ -146,7 +146,7 @@ public class JacksonSerializerTest {
         Assert.assertEquals(newRequest.getTargetServiceUniqueName(), request.getTargetServiceUniqueName());
         Assert.assertEquals(newRequest.getTargetAppName(), request.getTargetAppName());
         Assert.assertEquals(newRequest.getRequestProp(RemotingConstants.RPC_TRACE_NAME),
-                request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
+            request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
 
     }
 
@@ -272,7 +272,7 @@ public class JacksonSerializerTest {
             DemoRequest req = new DemoRequest();
             req.setName("123");
             serializer
-                    .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
+                .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
         } catch (Exception e) {
             error = true;
         }
@@ -286,9 +286,9 @@ public class JacksonSerializerTest {
             ObjectMapper mapper = new ObjectMapper();
             DemoRequest req = new DemoRequest();
             req.setName("123");
-            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] {req, "123"})),
-                    new SofaRequest(),
-                    errorHead2);
+            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] { req, "123" })),
+                new SofaRequest(),
+                errorHead2);
         } catch (Exception e) {
             error = true;
         }
@@ -312,7 +312,7 @@ public class JacksonSerializerTest {
         Assert.assertEquals(newRequest.getTargetServiceUniqueName(), request.getTargetServiceUniqueName());
         Assert.assertEquals(newRequest.getTargetAppName(), request.getTargetAppName());
         Assert.assertEquals(newRequest.getRequestProp(RemotingConstants.RPC_TRACE_NAME),
-                request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
+            request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
 
     }
 
@@ -348,7 +348,7 @@ public class JacksonSerializerTest {
             DemoRequest req = new DemoRequest();
             req.setName("123");
             serializer
-                    .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
+                .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
         } catch (Exception e) {
             error = true;
         }
@@ -362,9 +362,9 @@ public class JacksonSerializerTest {
             ObjectMapper mapper = new ObjectMapper();
             DemoRequest req = new DemoRequest();
             req.setName("123");
-            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] {req, "123"})),
-                    new SofaRequest(),
-                    errorHead2);
+            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] { req, "123" })),
+                new SofaRequest(),
+                errorHead2);
         } catch (Exception e) {
             error = true;
         }
@@ -388,14 +388,14 @@ public class JacksonSerializerTest {
         Assert.assertEquals(newRequest.getTargetServiceUniqueName(), request.getTargetServiceUniqueName());
         Assert.assertEquals(newRequest.getTargetAppName(), request.getTargetAppName());
         Assert.assertEquals(newRequest.getRequestProp(RemotingConstants.RPC_TRACE_NAME),
-                request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
+            request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
 
     }
 
     private SofaRequest buildSayRequest() throws NoSuchMethodException {
         final DemoRequest demoRequest = new DemoRequest();
         demoRequest.setName("name");
-        return buildRequest("say", new Object[] {demoRequest});
+        return buildRequest("say", new Object[] { demoRequest });
     }
 
     private SofaRequest buildSay2Request() throws NoSuchMethodException {
@@ -405,7 +405,7 @@ public class JacksonSerializerTest {
         Map<String, String> ctx = new HashMap<String, String>();
         ctx.put("abc", "123");
 
-        return buildRequest("say2", new Object[] {demoRequest, ctx, 123});
+        return buildRequest("say2", new Object[] { demoRequest, ctx, 123 });
     }
 
     private SofaRequest buildSay3Request() throws NoSuchMethodException {
@@ -415,7 +415,7 @@ public class JacksonSerializerTest {
         List<DemoRequest> list = new ArrayList<DemoRequest>();
         list.add(demoRequest);
 
-        return buildRequest("say3", new Object[] {list});
+        return buildRequest("say3", new Object[] { list });
     }
 
     private SofaRequest buildRequest(String methodName, Object[] args) throws NoSuchMethodException {

--- a/codec/codec-jackson/src/test/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializerTest.java
+++ b/codec/codec-jackson/src/test/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializerTest.java
@@ -146,7 +146,7 @@ public class JacksonSerializerTest {
         Assert.assertEquals(newRequest.getTargetServiceUniqueName(), request.getTargetServiceUniqueName());
         Assert.assertEquals(newRequest.getTargetAppName(), request.getTargetAppName());
         Assert.assertEquals(newRequest.getRequestProp(RemotingConstants.RPC_TRACE_NAME),
-            request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
+                request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
 
     }
 
@@ -214,6 +214,33 @@ public class JacksonSerializerTest {
     }
 
     @Test
+    public void testListResponse() {
+        // success response
+        Map<String, String> head = new HashMap<String, String>();
+        head.put(RemotingConstants.HEAD_TARGET_SERVICE, DemoService.class.getCanonicalName() + ":1.0");
+        head.put(RemotingConstants.HEAD_METHOD_NAME, "say3");
+        head.put(RemotingConstants.HEAD_TARGET_APP, "targetApp");
+        head.put(RemotingConstants.RPC_TRACE_NAME + ".a", "xxx");
+        head.put(RemotingConstants.RPC_TRACE_NAME + ".b", "yyy");
+        SofaResponse response = new SofaResponse();
+        final DemoResponse response1 = new DemoResponse();
+        response1.setWord("result");
+
+        List<DemoResponse> listResponse = new ArrayList<DemoResponse>();
+        listResponse.add(response1);
+
+        response.setAppResponse(listResponse);
+
+        AbstractByteBuf data = serializer.encode(response, null);
+        SofaResponse newResponse = new SofaResponse();
+        serializer.decode(data, newResponse, head);
+        Assert.assertFalse(newResponse.isError());
+        Assert.assertEquals(response.getAppResponse(), newResponse.getAppResponse());
+        Assert.assertEquals("result", ((List<DemoResponse>) newResponse.getAppResponse()).get(0).getWord());
+
+    }
+
+    @Test
     public void testMoreParameters() throws NoSuchMethodException {
         SofaRequest request = buildSay2Request();
         AbstractByteBuf data = serializer.encode(request, null);
@@ -245,7 +272,7 @@ public class JacksonSerializerTest {
             DemoRequest req = new DemoRequest();
             req.setName("123");
             serializer
-                .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
+                    .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
         } catch (Exception e) {
             error = true;
         }
@@ -259,9 +286,9 @@ public class JacksonSerializerTest {
             ObjectMapper mapper = new ObjectMapper();
             DemoRequest req = new DemoRequest();
             req.setName("123");
-            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] { req, "123" })),
-                new SofaRequest(),
-                errorHead2);
+            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] {req, "123"})),
+                    new SofaRequest(),
+                    errorHead2);
         } catch (Exception e) {
             error = true;
         }
@@ -285,7 +312,7 @@ public class JacksonSerializerTest {
         Assert.assertEquals(newRequest.getTargetServiceUniqueName(), request.getTargetServiceUniqueName());
         Assert.assertEquals(newRequest.getTargetAppName(), request.getTargetAppName());
         Assert.assertEquals(newRequest.getRequestProp(RemotingConstants.RPC_TRACE_NAME),
-            request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
+                request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
 
     }
 
@@ -321,7 +348,7 @@ public class JacksonSerializerTest {
             DemoRequest req = new DemoRequest();
             req.setName("123");
             serializer
-                .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
+                    .decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(req)), new SofaRequest(), errorHead1);
         } catch (Exception e) {
             error = true;
         }
@@ -335,9 +362,9 @@ public class JacksonSerializerTest {
             ObjectMapper mapper = new ObjectMapper();
             DemoRequest req = new DemoRequest();
             req.setName("123");
-            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] { req, "123" })),
-                new SofaRequest(),
-                errorHead2);
+            serializer.decode(new ByteArrayWrapperByteBuf(mapper.writeValueAsBytes(new Object[] {req, "123"})),
+                    new SofaRequest(),
+                    errorHead2);
         } catch (Exception e) {
             error = true;
         }
@@ -361,14 +388,14 @@ public class JacksonSerializerTest {
         Assert.assertEquals(newRequest.getTargetServiceUniqueName(), request.getTargetServiceUniqueName());
         Assert.assertEquals(newRequest.getTargetAppName(), request.getTargetAppName());
         Assert.assertEquals(newRequest.getRequestProp(RemotingConstants.RPC_TRACE_NAME),
-            request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
+                request.getRequestProp(RemotingConstants.RPC_TRACE_NAME));
 
     }
 
     private SofaRequest buildSayRequest() throws NoSuchMethodException {
         final DemoRequest demoRequest = new DemoRequest();
         demoRequest.setName("name");
-        return buildRequest("say", new Object[] { demoRequest });
+        return buildRequest("say", new Object[] {demoRequest});
     }
 
     private SofaRequest buildSay2Request() throws NoSuchMethodException {
@@ -378,7 +405,7 @@ public class JacksonSerializerTest {
         Map<String, String> ctx = new HashMap<String, String>();
         ctx.put("abc", "123");
 
-        return buildRequest("say2", new Object[] { demoRequest, ctx, 123 });
+        return buildRequest("say2", new Object[] {demoRequest, ctx, 123});
     }
 
     private SofaRequest buildSay3Request() throws NoSuchMethodException {
@@ -388,7 +415,7 @@ public class JacksonSerializerTest {
         List<DemoRequest> list = new ArrayList<DemoRequest>();
         list.add(demoRequest);
 
-        return buildRequest("say3", new Object[] { list });
+        return buildRequest("say3", new Object[] {list});
     }
 
     private SofaRequest buildRequest(String methodName, Object[] args) throws NoSuchMethodException {

--- a/codec/codec-jackson/src/test/java/com/alipay/sofa/rpc/codec/jackson/model/DemoService.java
+++ b/codec/codec-jackson/src/test/java/com/alipay/sofa/rpc/codec/jackson/model/DemoService.java
@@ -29,6 +29,6 @@ public interface DemoService {
 
     public DemoResponse say2(DemoRequest demoRequest, Map<String, String> ctx, int id);
 
-    public DemoResponse say3(List<DemoRequest> list);
+    public List<DemoResponse> say3(List<DemoRequest> list);
 
 }


### PR DESCRIPTION
### Motivation:

When response type is generic type, json decode occur error.

```
public List<DemoResponse> say3(List<DemoRequest> list);
```

### Modification:

Save response generic type to jackson's JavaType.

### Result:

