### PR TITLE
fix:fix jackson bind to 2.9.10.4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,7 +33,7 @@
         <thrift.version>0.9.2</thrift.version>
         <protobuf.version>3.5.1</protobuf.version>
         <jackson.version>2.9.10</jackson.version>
-        <jackson.databind.version>2.9.10.3</jackson.databind.version>
+        <jackson.databind.version>2.9.10.4</jackson.databind.version>
         <msgpack.version>0.6.12</msgpack.version>
         <protostuff.version>1.5.9</protostuff.version>
         <grpc.version>1.27.2</grpc.version>


### PR DESCRIPTION
### Motivation:

fix https://github.com/sofastack/sofa-rpc/network/alert/bom/pom.xml/com.fasterxml.jackson.core:jackson-databind/open

### Modification:

update version to 2.9.10.4

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
