### PR TITLE
feat(javassist-proxy): support static method of interface

### DIFF
--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -138,7 +138,8 @@ public class JavassistProxy implements Proxy {
         int mi = 0;
         for (Method m : methodAry) {
             mi++;
-            if (Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers()) || Modifier.isStatic(m.getModifiers())) {
+            if (Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers()) ||
+                Modifier.isStatic(m.getModifiers())) {
                 continue;
             }
             Class<?>[] mType = m.getParameterTypes();

--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -95,8 +95,8 @@ public class JavassistProxy implements Proxy {
                 constructor.setBody("{super(new " + UselessInvocationHandler.class.getName() + "());}");
                 mCtc.addConstructor(constructor);
 
-                List<String> fieldList = new ArrayList<>();
-                List<String> methodList = new ArrayList<>();
+                List<String> fieldList = new ArrayList<String>();
+                List<String> methodList = new ArrayList<String>();
 
                 fieldList.add("public " + Invoker.class.getCanonicalName() + " proxyInvoker = null;");
                 createMethod(interfaceClass, fieldList, methodList);

--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -95,8 +95,8 @@ public class JavassistProxy implements Proxy {
                 constructor.setBody("{super(new " + UselessInvocationHandler.class.getName() + "());}");
                 mCtc.addConstructor(constructor);
 
-                List<String> fieldList = new ArrayList<String>();
-                List<String> methodList = new ArrayList<String>();
+                List<String> fieldList = new ArrayList<>();
+                List<String> methodList = new ArrayList<>();
 
                 fieldList.add("public " + Invoker.class.getCanonicalName() + " proxyInvoker = null;");
                 createMethod(interfaceClass, fieldList, methodList);
@@ -138,7 +138,7 @@ public class JavassistProxy implements Proxy {
         int mi = 0;
         for (Method m : methodAry) {
             mi++;
-            if (Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers())) {
+            if (Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers()) || Modifier.isStatic(m.getModifiers())) {
                 continue;
             }
             Class<?>[] mType = m.getParameterTypes();

--- a/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/TestInterface.java
+++ b/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/TestInterface.java
@@ -41,4 +41,8 @@ public interface TestInterface {
     public String throwbiz2() throws Throwable;
 
     public String throwRPC();
+
+    static void doNothing() {
+
+    }
 }


### PR DESCRIPTION
### Motivation:

当前的sofa-rpc在接口中定义静态方法时会抛出异常，希望避免这种情况。

### Modification:

避免给静态方法生成代理方法。

### Result:

Fixes #1051. 