### PR TITLE
feat: try to obtain the unique service name from headerMap

### DIFF
--- a/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
+++ b/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
@@ -421,6 +421,9 @@ public class SofaRpcSerialization extends DefaultCustomSerializer {
         // Try to obtain the unique name of the target service from the headerMap.
         // Due to the MOSN routing logic, it may be different from the original service unique name.
         String headerService = headerMap.get(RemotingConstants.HEAD_SERVICE);
+        if (headerService == null) {
+            headerService = headerMap.get(RemotingConstants.HEAD_TARGET_SERVICE);
+        }
         if (StringUtils.isNotBlank(headerService)) {
             request.setTargetServiceUniqueName(headerService);
         }

--- a/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
+++ b/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
@@ -263,12 +263,7 @@ public class SofaRpcSerialization extends DefaultCustomSerializer {
                         for (Map.Entry<String, String> entry : headerMap.entrySet()) {
                             ((SofaRequest) sofaRequest).addRequestProp(entry.getKey(), entry.getValue());
                         }
-                    }
-                    // Try to obtain the unique name of the target service from the headerMap.
-                    // Due to the MOSN routing logic, it may be different from the original service unique name.
-                    String headerService = headerMap.get(RemotingConstants.HEAD_SERVICE);
-                    if (StringUtils.isNotBlank(headerService)) {
-                        ((SofaRequest) sofaRequest).setTargetServiceUniqueName(headerService);
+                        setRequestPropertiesWithHeaderInfo(headerMap, ((SofaRequest) sofaRequest));
                     }
                     requestCommand.setRequestObject(sofaRequest);
                 } finally {
@@ -416,4 +411,19 @@ public class SofaRpcSerialization extends DefaultCustomSerializer {
         context.setAttachment(RpcConstants.INTERNAL_KEY_RESP_SIZE, respSize);
         context.setAttachment(RpcConstants.INTERNAL_KEY_RESP_DESERIALIZE_TIME, cost);
     }
+
+    /**
+     * 使用header中的值替换部分请求属性
+     * @param headerMap header
+     * @param request SofaRequest
+     */
+    protected void setRequestPropertiesWithHeaderInfo(Map<String, String> headerMap, SofaRequest request) {
+        // Try to obtain the unique name of the target service from the headerMap.
+        // Due to the MOSN routing logic, it may be different from the original service unique name.
+        String headerService = headerMap.get(RemotingConstants.HEAD_SERVICE);
+        if (StringUtils.isNotBlank(headerService)) {
+            request.setTargetServiceUniqueName(headerService);
+        }
+    }
+
 }

--- a/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
+++ b/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
@@ -264,7 +264,12 @@ public class SofaRpcSerialization extends DefaultCustomSerializer {
                             ((SofaRequest) sofaRequest).addRequestProp(entry.getKey(), entry.getValue());
                         }
                     }
-
+                    // Try to obtain the unique name of the target service from the headerMap.
+                    // Due to the MOSN routing logic, it may be different from the original service unique name.
+                    String headerService = headerMap.get(RemotingConstants.HEAD_SERVICE);
+                    if (StringUtils.isNotBlank(headerService)) {
+                        ((SofaRequest) sofaRequest).setTargetServiceUniqueName(headerService);
+                    }
                     requestCommand.setRequestObject(sofaRequest);
                 } finally {
                     Thread.currentThread().setContextClassLoader(oldClassLoader);


### PR DESCRIPTION
   Try to obtain the unique name of the target service from the headerMap.
   Due to the MOSN routing logic, it may be different from the original service unique name.

### Motivation:

   Try to obtain the unique name of the target service from the headerMap.
   Due to the MOSN routing logic, it may be different from the original service unique name.

### Modification:

  try to get the unique name from headerMap in com.alipay.sofa.rpc.codec.bolt.SofaRpcSerialization#deserializeContent(Request)

### Result:

with this modification, MOSN can modify original unique service name to redirect request to another service
