### PR TITLE
modify 基于bolt协议和json序列化的泛化调用

### DIFF
--- a/bootstrap/bootstrap-bolt/src/main/java/com/alipay/sofa/rpc/bootstrap/bolt/BoltClientProxyInvoker.java
+++ b/bootstrap/bootstrap-bolt/src/main/java/com/alipay/sofa/rpc/bootstrap/bolt/BoltClientProxyInvoker.java
@@ -22,10 +22,7 @@ import com.alipay.sofa.rpc.common.RemotingConstants;
 import com.alipay.sofa.rpc.config.ConfigUniqueNameGenerator;
 import com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException;
 
-import static com.alipay.sofa.rpc.common.RpcConstants.SERIALIZE_HESSIAN;
-import static com.alipay.sofa.rpc.common.RpcConstants.SERIALIZE_HESSIAN2;
-import static com.alipay.sofa.rpc.common.RpcConstants.SERIALIZE_JAVA;
-import static com.alipay.sofa.rpc.common.RpcConstants.SERIALIZE_PROTOBUF;
+import static com.alipay.sofa.rpc.common.RpcConstants.*;
 
 /**
  * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
@@ -57,6 +54,8 @@ public class BoltClientProxyInvoker extends DefaultClientProxyInvoker {
             serializeType = RemotingConstants.SERIALIZE_CODE_PROTOBUF;
         } else if (SERIALIZE_JAVA.equals(serialization)) {
             serializeType = RemotingConstants.SERIALIZE_CODE_JAVA;
+        } else if (SERIALIZE_JSON.equals(serialization)) {
+            serializeType = RemotingConstants.SERIALIZE_CODE_JSON;
         } else {
             serializeType = super.parseSerializeType(serialization);
         }

--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/RemotingConstants.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/RemotingConstants.java
@@ -81,6 +81,13 @@ public class RemotingConstants {
     public static final byte   SERIALIZE_CODE_PROTOBUF    = 11;
 
     /**
+     * json  对应bolt固定同步里的codec字段
+     *
+     * @see com.alipay.sofa.rpc.common.RpcConstants#SERIALIZE_JSON
+     */
+    public static final Byte   SERIALIZE_CODE_JSON        = 12;
+
+    /**
      * 普通序列化：序列化反序列化均使用SofaSerializerFactory
      */
     public static final String SERIALIZE_FACTORY_NORMAL   = "0";

--- a/example/src/test/java/com/alipay/sofa/rpc/invoke/generic/GenericClientMain.java
+++ b/example/src/test/java/com/alipay/sofa/rpc/invoke/generic/GenericClientMain.java
@@ -24,6 +24,9 @@ import com.alipay.sofa.rpc.context.RpcRuntimeContext;
 import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  *
  *
@@ -52,7 +55,7 @@ public class GenericClientMain {
                     new Object[] { "1111" });
                 LOGGER.warn("generic return :{}", s1);
 
-                GenericObject genericObject = new GenericObject(
+                /*GenericObject genericObject = new GenericObject(
                     "com.alipay.sofa.rpc.invoke.generic.TestObj");
                 genericObject.putField("str", "xxxx");
                 genericObject.putField("num", 222);
@@ -65,7 +68,16 @@ public class GenericClientMain {
                 TestObj o3 = testService.$genericInvoke("echoObj",
                     new String[] { "com.alipay.sofa.rpc.invoke.generic.TestObj" },
                     new Object[] { genericObject }, TestObj.class);
-                LOGGER.warn("generic return :{}", o3);
+                LOGGER.warn("generic return :{}", o3);*/
+
+                Map<String, Object> map = new HashMap<>();
+                map.put("str", "xxxx");
+                map.put("num", 222);
+
+                TestObj o4 =  (TestObj) testService.$invoke("echoObj",
+                        new String[] { "java.util.HashMap" },
+                        new Object[] { map });
+                LOGGER.warn("generic return!!!!!!!!! :{}", o4);
 
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);

--- a/example/src/test/java/com/alipay/sofa/rpc/triple/GenericTripleDemo.java
+++ b/example/src/test/java/com/alipay/sofa/rpc/triple/GenericTripleDemo.java
@@ -17,11 +17,7 @@
 package com.alipay.sofa.rpc.triple;
 
 import com.alipay.sofa.rpc.common.RpcConstants;
-import com.alipay.sofa.rpc.config.ApplicationConfig;
-import com.alipay.sofa.rpc.config.ConsumerConfig;
-import com.alipay.sofa.rpc.config.ProviderConfig;
-import com.alipay.sofa.rpc.config.RegistryConfig;
-import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.config.*;
 import com.alipay.sofa.rpc.context.RpcRunningState;
 import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;

--- a/example/src/test/java/com/alipay/sofa/rpc/triple/OriginHello.java
+++ b/example/src/test/java/com/alipay/sofa/rpc/triple/OriginHello.java
@@ -16,9 +16,6 @@
  */
 package com.alipay.sofa.rpc.triple;
 
-import io.grpc.examples.helloworld.HelloReply;
-import io.grpc.examples.helloworld.HelloRequest;
-
 /**
  * @author zhaowang
  * @version : OriginHello.java, v 0.1 2020年05月28日 3:10 下午 zhaowang Exp $

--- a/example/src/test/java/com/alipay/sofa/rpc/triple/SingleTripleDemo.java
+++ b/example/src/test/java/com/alipay/sofa/rpc/triple/SingleTripleDemo.java
@@ -17,11 +17,7 @@
 package com.alipay.sofa.rpc.triple;
 
 import com.alipay.sofa.rpc.common.RpcConstants;
-import com.alipay.sofa.rpc.config.ApplicationConfig;
-import com.alipay.sofa.rpc.config.ConsumerConfig;
-import com.alipay.sofa.rpc.config.ProviderConfig;
-import com.alipay.sofa.rpc.config.RegistryConfig;
-import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.config.*;
 import com.alipay.sofa.rpc.context.RpcRunningState;
 import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;

--- a/example/src/test/java/com/alipay/sofa/rpc/triple/TripleGreeterImpl.java
+++ b/example/src/test/java/com/alipay/sofa/rpc/triple/TripleGreeterImpl.java
@@ -20,9 +20,6 @@ import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
 import io.grpc.examples.helloworld.SofaGreeterTriple;
 import io.grpc.stub.StreamObserver;
-import org.springframework.util.ClassUtils;
-
-import java.util.Set;
 
 public class TripleGreeterImpl extends SofaGreeterTriple.GreeterImplBase {
 


### PR DESCRIPTION
### Motivation:

在泛化调用中增加对于json序列化器的支持

### Modification:

在remotingConstants中添加json序列化器对应常量，在boltCilentProxyInvoker中增加对json序列化器选择的逻辑判断

### Result:

通过在rpc-config文件中添加"default.serialization": "json"可以选择序列化器为json

If there is no issue then describe the changes introduced by this PR.
