### PR TITLE
Inefficient Usage of Java Collection

### DIFF
--- a/codec/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoader.java
+++ b/codec/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/BlackListFileLoader.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import static com.alipay.sofa.rpc.common.utils.IOUtils.closeQuietly;
@@ -104,7 +105,7 @@ public class BlackListFileLoader {
      * @param overrideStr The override string
      */
     static void overrideBlackList(List<String> originList, String overrideStr) {
-        List<String> adds = new ArrayList<String>();
+        List<String> adds = new LinkedList<String>();
         String[] overrideItems = StringUtils.splitWithCommaOrSemicolon(overrideStr);
         for (String overrideItem : overrideItems) {
             if (StringUtils.isNotBlank(overrideItem)) {

--- a/compiler/src/main/java/com/alipay/sofa/gen/base/AbstractGenerator.java
+++ b/compiler/src/main/java/com/alipay/sofa/gen/base/AbstractGenerator.java
@@ -31,6 +31,7 @@ import com.salesforce.jprotoc.GeneratorException;
 import com.salesforce.jprotoc.ProtoTypeMap;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -122,7 +123,7 @@ public abstract class AbstractGenerator extends Generator {
         serviceContext.setServiceName(serviceProto.getName());
         serviceContext.setDeprecated(serviceProto.getOptions() != null && serviceProto.getOptions().getDeprecated());
 
-        List<Location> allLocationsForService = new ArrayList<>();
+        List<Location> allLocationsForService = new LinkedList<>();
         for (Location location : locations) {
             if (location.getPathCount() >= 2 &&
                     location.getPath(0) == FileDescriptorProto.SERVICE_FIELD_NUMBER &&

--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AllConnectConnectionHolder.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AllConnectConnectionHolder.java
@@ -790,7 +790,7 @@ public class AllConnectConnectionHolder extends ConnectionHolder {
     public Map<String, Set<ProviderInfo>> currentProviderMap() {
         providerLock.lock();
         try {
-            Map<String, Set<ProviderInfo>> tmp = new LinkedHashMap<String, Set<ProviderInfo>>();
+            Map<String, Set<ProviderInfo>> tmp = new HashMap<String, Set<ProviderInfo>>();
             tmp.put("alive", new HashSet<ProviderInfo>(aliveConnections.keySet()));
             tmp.put("subHealth", new HashSet<ProviderInfo>(subHealthConnections.keySet()));
             tmp.put("retry", new HashSet<ProviderInfo>(retryConnections.keySet()));

--- a/core/api/src/main/java/com/alipay/sofa/rpc/client/RouterChain.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/client/RouterChain.java
@@ -31,6 +31,7 @@ import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -100,7 +101,7 @@ public class RouterChain {
     private final List<Router> routers;
 
     public RouterChain(List<Router> actualRouters, ConsumerBootstrap consumerBootstrap) {
-        this.routers = new ArrayList<Router>();
+        this.routers = new LinkedList<Router>();
         if (CommonUtils.isNotEmpty(actualRouters)) {
             for (Router router : actualRouters) {
                 if (router.needToLoad(consumerBootstrap)) {

--- a/core/api/src/main/java/com/alipay/sofa/rpc/filter/FilterChain.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/filter/FilterChain.java
@@ -36,6 +36,7 @@ import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -121,7 +122,7 @@ public class FilterChain implements Invoker {
         // 前面的过滤器在最外层
         invokerChain = lastInvoker;
         if (CommonUtils.isNotEmpty(filters)) {
-            loadedFilters = new ArrayList<Filter>();
+            loadedFilters = new LinkedList<Filter>();
             for (int i = filters.size() - 1; i >= 0; i--) {
                 try {
                     Filter filter = filters.get(i);

--- a/core/api/src/main/java/com/alipay/sofa/rpc/filter/FilterChain.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/filter/FilterChain.java
@@ -190,7 +190,7 @@ public class FilterChain implements Invoker {
         HashSet<String> excludes = parseExcludeFilter(customFilters);
 
         // 准备数据：用户通过别名的方式注入的filter，需要解析
-        List<ExtensionClass<Filter>> extensionFilters = new ArrayList<ExtensionClass<Filter>>();
+        List<ExtensionClass<Filter>> extensionFilters = new LinkedList<ExtensionClass<Filter>>();
         List<String> filterAliases = config.getFilter(); //
         if (CommonUtils.isNotEmpty(filterAliases)) {
             for (String filterAlias : filterAliases) {

--- a/doc-swagger/src/main/java/com/alipay/sofa/rpc/doc/swagger/generate/Reader.java
+++ b/doc-swagger/src/main/java/com/alipay/sofa/rpc/doc/swagger/generate/Reader.java
@@ -109,7 +109,7 @@ public class Reader {
                 return o1.getName().compareTo(o2.getName());
             }
         });
-        Map<Method, Method> serviceMethods = new LinkedHashMap<Method, Method>();
+        Map<Method, Method> serviceMethods = new HashMap<Method, Method>();
         for (Method method : interfaceMethodList) {
             if (!ReflectionUtils.isOverriddenMethod(method, context.getCls())) {
                 serviceMethods.put(method, getRefMethod(context, method));

--- a/remoting/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/config/JAXRSProviderManager.java
+++ b/remoting/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/config/JAXRSProviderManager.java
@@ -17,7 +17,7 @@
 package com.alipay.sofa.rpc.config;
 
 import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -31,12 +31,12 @@ public class JAXRSProviderManager {
     /**
      * 内置的jaxrs Provider类
      */
-    private static Set<Class>  internalProviderClasses = Collections.synchronizedSet(new LinkedHashSet<Class>());
+    private static Set<Class>  internalProviderClasses = Collections.synchronizedSet(new HashSet<Class>());
 
     /**
      * 自定义jaxrs Provider实例
      */
-    private static Set<Object> customProviderInstances = Collections.synchronizedSet(new LinkedHashSet<Object>());
+    private static Set<Object> customProviderInstances = Collections.synchronizedSet(new HashSet<Object>());
 
     /**
      * 注册内置的jaxrs Provider类

--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/common/MetadataHolder.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/common/MetadataHolder.java
@@ -30,7 +30,7 @@ public class MetadataHolder {
     public static Map<String, String> getMetaHolder() {
         Map<String, String> stringStringMap = localContext.get();
         if(stringStringMap == null){
-            LinkedHashMap<String, String> value = new HashMap<>();
+            HashMap<String, String> value = new HashMap<>();
             localContext.set(value);
             return value;
         }

--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/common/MetadataHolder.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/common/MetadataHolder.java
@@ -17,7 +17,7 @@
 package com.alipay.sofa.rpc.common;
 
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -30,7 +30,7 @@ public class MetadataHolder {
     public static Map<String, String> getMetaHolder() {
         Map<String, String> stringStringMap = localContext.get();
         if(stringStringMap == null){
-            LinkedHashMap<String, String> value = new LinkedHashMap<>();
+            LinkedHashMap<String, String> value = new HashMap<>();
             localContext.set(value);
             return value;
         }

--- a/tracer/tracer-opentracing-resteasy/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/RestTracerAdapter.java
+++ b/tracer/tracer-opentracing-resteasy/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/RestTracerAdapter.java
@@ -338,7 +338,7 @@ public class RestTracerAdapter {
                 return;
             }
 
-            Map<String, String> baggageItems = new LinkedHashMap<String, String>();
+            Map<String, String> baggageItems = new HashMap<String, String>();
             for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
                 if (!entry.getKey().startsWith(RPC_RESPONSE_BAGGAGE_PREFIX) ||
                     entry.getValue() == null ||


### PR DESCRIPTION
Hi,

We find that there are several ArrayList objects which are not manipulated by random access. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these objects are only used for traversal, the retrieval, and removal of the first or the last element.

This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

Meanwhile, we also found several LinkedHashSet and LinkedHashMap objects which are not necessary to maintain the order of insertions. To achieve the same functionality, HashHap and HashSet are enough. The replacement can also reduce the time cost in the modification of the map objects.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto