### PR TITLE
fix RpcInvokeContext not thread safe

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
@@ -21,7 +21,6 @@ import com.alipay.sofa.rpc.common.RpcOptions;
 import com.alipay.sofa.rpc.core.invoke.SofaResponseCallback;
 import com.alipay.sofa.rpc.message.ResponseFuture;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
@@ -68,7 +68,7 @@ public class RpcInvokeContext {
     /**
      * 自定义属性
      */
-    protected Map<String, Object> map = new ConcurrentHashMap<String, Object>();
+    protected Map<String, Object> map = new ConcurrentHashMap<>();
     /**
      * 请求上的透传数据
      *
@@ -80,7 +80,7 @@ public class RpcInvokeContext {
      *
      * @since 5.1.2
      */
-    protected Map<String, String> responseBaggage = BAGGAGE_ENABLE ? new ConcurrentHashMap<String, String>() : null;
+    protected Map<String, String> responseBaggage = BAGGAGE_ENABLE ? new ConcurrentHashMap<>() : null;
 
     /**
      * 得到上下文，没有则初始化
@@ -449,6 +449,7 @@ public class RpcInvokeContext {
         sb.append(", map=").append(map);
         sb.append(", requestBaggage=").append(requestBaggage);
         sb.append(", responseBaggage=").append(responseBaggage);
+        sb.append(", customHeader=").append(customHeader);
         sb.append('}');
         return sb.toString();
     }

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
@@ -115,6 +115,9 @@ public class RpcInvokeContext {
     }
 
     private static RpcInvokeContext clone(RpcInvokeContext parent) {
+        if( parent == null ){
+            return null;
+        }
         RpcInvokeContext child = new RpcInvokeContext();
         //timeout
         child.setTimeout(parent.getTimeout());

--- a/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
@@ -20,7 +20,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  *
@@ -123,4 +125,49 @@ public class RpcInvokeContextTest {
         Assert.assertTrue(context != RpcInvokeContext.getContext());
         RpcInvokeContext.removeContext();
     }
+
+    @Test
+    public void testConcurrentModify() throws InterruptedException {
+        for (int i = 0; i < 10; i++) {
+            RpcInvokeContext.getContext().put(""+i,""+i);
+        }
+
+        CountDownLatch countDownLatch = new CountDownLatch(2);
+        RpcInvokeContext mainContext = RpcInvokeContext.getContext();
+        AtomicReference<RuntimeException> exceptionHolder = new AtomicReference<>();
+        new Thread(()->{
+            countDownLatch.countDown();
+            try {
+                countDownLatch.await();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            long start = System.currentTimeMillis();
+            try{
+                while(System.currentTimeMillis() - start < 100){
+                    RpcInvokeContext.setContext(mainContext);
+                }
+            }catch (RuntimeException e){
+                exceptionHolder.set(e);
+                throw e;
+            }
+
+        }).start();
+
+        Map<String, String> headers = RpcInvokeContext.getContext().getCustomHeader();
+        countDownLatch.countDown();
+        countDownLatch.await();
+        long start = System.currentTimeMillis();
+        int i = 0;
+        while(System.currentTimeMillis()-start < 100){
+            if(exceptionHolder.get()!=null){
+                throw exceptionHolder.get();
+            }
+            headers.put(""+i,""+i);
+            i++;
+        }
+    }
+
+
+
 }

--- a/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
@@ -53,7 +53,7 @@ public class RpcInvokeContextTest {
             context = new RpcInvokeContext();
             RpcInvokeContext.setContext(context);
             Assert.assertTrue(RpcInvokeContext.getContext() != null);
-            Assert.assertEquals(RpcInvokeContext.getContext(), context);
+            Assert.assertNotEquals(RpcInvokeContext.getContext(), context);
 
             RpcInvokeContext.removeContext();
             Assert.assertTrue(RpcInvokeContext.peekContext() == null);
@@ -104,5 +104,23 @@ public class RpcInvokeContextTest {
 
         new Thread(runnable).start();
         runnable.run();
+    }
+
+    @Test
+    public void testSetContext() {
+        RpcInvokeContext context = new RpcInvokeContext();
+        context.setTargetGroup("target");
+        context.setTargetURL("url");
+        context.setTimeout(111);
+        context.addCustomHeader("A", "B");
+        context.put("C", "D");
+        RpcInvokeContext.setContext(context);
+        Assert.assertEquals(context.getTargetGroup(), RpcInvokeContext.getContext().getTargetGroup());
+        Assert.assertEquals(context.getTargetURL(), RpcInvokeContext.getContext().getTargetURL());
+        Assert.assertEquals(context.getTimeout(), RpcInvokeContext.getContext().getTimeout());
+        Assert.assertEquals("B", RpcInvokeContext.getContext().getCustomHeader().get("A"));
+        Assert.assertEquals("D", RpcInvokeContext.getContext().get("C"));
+        Assert.assertTrue(context != RpcInvokeContext.getContext());
+        RpcInvokeContext.removeContext();
     }
 }

--- a/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
@@ -25,8 +25,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- *
- *
  * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
  */
 public class RpcInvokeContextTest {
@@ -73,7 +71,7 @@ public class RpcInvokeContextTest {
     }
 
     @Test
-    public void testThreadSafe(){
+    public void testThreadSafe() {
         RpcInvokeContext context = RpcInvokeContext.getContext();
         CountDownLatch countDownLatch = new CountDownLatch(2);
         Runnable runnable = new Runnable() {
@@ -93,11 +91,11 @@ public class RpcInvokeContextTest {
                     now = System.currentTimeMillis();
                     i++;
                     RpcInvokeContext.getContext().addCustomHeader(i + "", i + "");
-                    try{
+                    try {
                         new HashMap<>().putAll(RpcInvokeContext.getContext().getCustomHeader());
-                    }catch (Exception e){
+                    } catch (Exception e) {
                         System.out.println(i);
-                        throw  e ;
+                        throw e;
                     }
                 }
 
@@ -129,13 +127,13 @@ public class RpcInvokeContextTest {
     @Test
     public void testConcurrentModify() throws InterruptedException {
         for (int i = 0; i < 10; i++) {
-            RpcInvokeContext.getContext().put(""+i,""+i);
+            RpcInvokeContext.getContext().put("" + i, "" + i);
         }
 
         CountDownLatch countDownLatch = new CountDownLatch(2);
         RpcInvokeContext mainContext = RpcInvokeContext.getContext();
         AtomicReference<RuntimeException> exceptionHolder = new AtomicReference<>();
-        new Thread(()->{
+        new Thread(() -> {
             countDownLatch.countDown();
             try {
                 countDownLatch.await();
@@ -143,11 +141,11 @@ public class RpcInvokeContextTest {
                 e.printStackTrace();
             }
             long start = System.currentTimeMillis();
-            try{
-                while(System.currentTimeMillis() - start < 100){
+            try {
+                while (System.currentTimeMillis() - start < 100) {
                     RpcInvokeContext.setContext(mainContext);
                 }
-            }catch (RuntimeException e){
+            } catch (RuntimeException e) {
                 exceptionHolder.set(e);
                 throw e;
             }
@@ -159,15 +157,12 @@ public class RpcInvokeContextTest {
         countDownLatch.await();
         long start = System.currentTimeMillis();
         int i = 0;
-        while(System.currentTimeMillis()-start < 100){
-            if(exceptionHolder.get()!=null){
+        while (System.currentTimeMillis() - start < 100) {
+            if (exceptionHolder.get() != null) {
                 throw exceptionHolder.get();
             }
-            headers.put(""+i,""+i);
+            headers.put("" + i, "" + i);
             i++;
         }
     }
-
-
-
 }

--- a/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.rpc.context;
 
-import com.sun.javafx.geom.ConcentricShapePair;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -106,5 +105,4 @@ public class RpcInvokeContextTest {
         new Thread(runnable).start();
         runnable.run();
     }
-
 }

--- a/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallback.java
+++ b/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallback.java
@@ -73,16 +73,24 @@ public abstract class AbstractInvokeCallback implements InvokeCallback {
 
     protected void pickupBaggage(SofaResponse response) {
         if (RpcInvokeContext.isBaggageEnable()) {
-            RpcInvokeContext invokeCtx = null;
+            RpcInvokeContext old = null;
+            RpcInvokeContext newContext = null;
             if (context != null) {
-                invokeCtx = (RpcInvokeContext) context.getAttachment(RpcConstants.HIDDEN_KEY_INVOKE_CONTEXT);
+                old = (RpcInvokeContext) context.getAttachment(RpcConstants.HIDDEN_KEY_INVOKE_CONTEXT);
             }
-            if (invokeCtx == null) {
-                invokeCtx = RpcInvokeContext.getContext();
+            if (old == null) {
+                newContext = RpcInvokeContext.getContext();
             } else {
-                RpcInvokeContext.setContext(invokeCtx);
+                RpcInvokeContext.setContext(old);
+                newContext = RpcInvokeContext.getContext();
             }
-            BaggageResolver.pickupFromResponse(invokeCtx, response);
+            BaggageResolver.pickupFromResponse(newContext, response);
+
+            if (old != null) {
+                old.getAllResponseBaggage().putAll(newContext.getAllResponseBaggage());
+                old.getAllRequestBaggage().putAll(newContext.getAllRequestBaggage());
+            }
+
         }
     }
 }

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttpClientHandler.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttpClientHandler.java
@@ -103,6 +103,7 @@ public abstract class AbstractHttpClientHandler implements ClientHandler {
                 invokeCtx = RpcInvokeContext.getContext();
             } else {
                 RpcInvokeContext.setContext(invokeCtx);
+                invokeCtx = RpcInvokeContext.getContext();
             }
             BaggageResolver.pickupFromResponse(invokeCtx, response);
         }

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BAsyncChainSampleServiceImpl.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BAsyncChainSampleServiceImpl.java
@@ -83,7 +83,7 @@ public class BAsyncChainSampleServiceImpl implements SampleService {
             LOGGER.info("--b2---:" + RpcInvokeContext.getContext());
             latch.await(5000, TimeUnit.MILLISECONDS); // 模拟Callback更早回来的行为
             context.putResponseBaggage("respBaggageB_useless2", "在返A之前写后没用"); // 返回写在这里可能没用
-            LOGGER.info("--b3---:" + RpcInvokeContext.getContext());
+            LOGGER.info("--b5---:" + RpcInvokeContext.getContext());
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageAsyncChainTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageAsyncChainTest.java
@@ -112,12 +112,18 @@ public class BaggageAsyncChainTest extends BaggageBaseTest {
         MethodConfig methodConfigA = new MethodConfig()
             .setName("hello")
             .setInvokeType(RpcConstants.INVOKER_TYPE_CALLBACK);
+        final Exception[] exp = new Exception[1];
         methodConfigA.setOnReturn(new SofaResponseCallback() {
             @Override
             public void onAppResponse(Object appResponse, String methodName, RequestBase request) {
-                Assert.assertNotSame(RpcInvokeContext.getContext(), contexts[0]); // 主线程和子线程中的 Context 必须不是同一个，否则有并发问题
-                str[0] = (String) appResponse;
-                latch[0].countDown();
+                try {
+                    Assert.assertNotSame(RpcInvokeContext.getContext(), contexts[0]); // 主线程和子线程中的 Context 必须不是同一个，否则有并发问题
+                    str[0] = (String) appResponse;
+                    latch[0].countDown();
+                } catch (Exception e) {
+                    exp[0] = e;
+                }
+
             }
 
             @Override
@@ -148,6 +154,9 @@ public class BaggageAsyncChainTest extends BaggageBaseTest {
         String ret = service.hello(); // 测试传递数据
         Assert.assertEquals(ret, null);
         latch[0].await(5000, TimeUnit.MILLISECONDS);
+        if (exp[0] != null) {
+            throw exp[0];
+        }
         ret = str[0];
         Assert.assertEquals(ret, "hello world chello world d");
         Assert.assertEquals(refB.getReqBaggage(), "a2bbb");

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageAsyncChainTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageAsyncChainTest.java
@@ -115,7 +115,7 @@ public class BaggageAsyncChainTest extends BaggageBaseTest {
         methodConfigA.setOnReturn(new SofaResponseCallback() {
             @Override
             public void onAppResponse(Object appResponse, String methodName, RequestBase request) {
-//                Assert.assertEquals(RpcInvokeContext.getContext(), contexts[0]); // 必须和调用线程一致
+                Assert.assertNotSame(RpcInvokeContext.getContext(), contexts[0]); // 主线程和子线程中的 Context 必须不是同一个，否则有并发问题
                 str[0] = (String) appResponse;
                 latch[0].countDown();
             }

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageAsyncChainTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageAsyncChainTest.java
@@ -115,7 +115,7 @@ public class BaggageAsyncChainTest extends BaggageBaseTest {
         methodConfigA.setOnReturn(new SofaResponseCallback() {
             @Override
             public void onAppResponse(Object appResponse, String methodName, RequestBase request) {
-                Assert.assertEquals(RpcInvokeContext.getContext(), contexts[0]); // 必须和调用线程一致
+//                Assert.assertEquals(RpcInvokeContext.getContext(), contexts[0]); // 必须和调用线程一致
                 str[0] = (String) appResponse;
                 latch[0].countDown();
             }

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageCallbackTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/baggage/BaggageCallbackTest.java
@@ -120,7 +120,7 @@ public class BaggageCallbackTest extends BaggageBaseTest {
         methodConfigA.setOnReturn(new SofaResponseCallback() {
             @Override
             public void onAppResponse(Object appResponse, String methodName, RequestBase request) {
-                Assert.assertEquals(RpcInvokeContext.getContext(), contexts[0]); // 必须和调用线程一致
+                Assert.assertNotSame(RpcInvokeContext.getContext(), contexts[0]);
                 str[0] = (String) appResponse;
                 latch[0].countDown();
             }


### PR DESCRIPTION
### Motivation:
RpcInvokeContext is not thread safe , I add ReadWriteLock in it to make it thread safe

### Modification:

Describe the idea and modifications you've done.

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
