### PR TITLE
update qr code for dingtalk group

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Runtime requirement: JDK 8 or above.
 
 - **DingTalk Group**
 
-  <img alt="DingTalk" src="https://gw.alipayobjects.com/mdn/sofastack/afts/img/A*am-XQKObyJ8AAAAAAAAAAABkARQnAQ" height="250" width="250">
+  <img alt="DingTalk" src="https://www.sofastack.tech/img/qrcode/qrcode_2.png" height="250" width="250">
 
 ## License
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -46,7 +46,7 @@ SOFARPC 是一个高可扩展性、高性能、生产级的 Java RPC 框架。�
 
 - **钉钉群**
 
-  <img alt="DingTalk" src="https://gw.alipayobjects.com/mdn/sofastack/afts/img/A*am-XQKObyJ8AAAAAAAAAAABkARQnAQ" height="250" width="250">
+  <img alt="DingTalk" src="https://www.sofastack.tech/img/qrcode/qrcode_2.png" height="250" width="250">
 
 ## 致谢
 


### PR DESCRIPTION
### Motivation:

The QR code of the dingtalk group is expired, we need to update it to a valid one.

### Modification:

replace the qr code with the one in https://www.sofastack.tech/

### Result:

Fixes #1085
