### PR TITLE
Deprecate unused logger method

### DIFF
--- a/log-common-tools/src/main/java/com/alipay/sofa/rpc/log/MiddlewareLoggerImpl.java
+++ b/log-common-tools/src/main/java/com/alipay/sofa/rpc/log/MiddlewareLoggerImpl.java
@@ -44,9 +44,6 @@ public class MiddlewareLoggerImpl implements Logger {
     }
 
     private org.slf4j.Logger getLogger(String appName) {
-        if (appName == null) {
-            return DEFAULT_LOGGER;
-        }
         return DEFAULT_LOGGER;
     }
 


### PR DESCRIPTION
### Motivation:
Deprecate unused logger method (with appname)
