### PR TITLE
Fix/baggage null

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/BaggageResolver.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/BaggageResolver.java
@@ -23,6 +23,7 @@ import com.alipay.sofa.rpc.core.response.SofaResponse;
 import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -47,7 +48,8 @@ public class BaggageResolver {
         if (context != null) {
             Map<String, String> requestBaggage = context.getAllRequestBaggage();
             if (CommonUtils.isNotEmpty(requestBaggage)) { // 需要透传
-                request.addRequestProp(RemotingConstants.RPC_REQUEST_BAGGAGE, requestBaggage);
+                HashMap<String, String> tmp = new HashMap<>(requestBaggage);
+                request.addRequestProp(RemotingConstants.RPC_REQUEST_BAGGAGE, tmp);
             }
         }
     }

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
@@ -226,7 +226,6 @@ public class RpcInvokeContext {
      */
     public void putRequestBaggage(String key, String value) {
         if (BAGGAGE_ENABLE && key != null && value != null) {
-
             requestBaggage.put(key, value);
         }
     }

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
@@ -19,10 +19,10 @@ package com.alipay.sofa.rpc.context;
 import com.alipay.sofa.rpc.common.RpcConfigs;
 import com.alipay.sofa.rpc.common.RpcOptions;
 import com.alipay.sofa.rpc.core.invoke.SofaResponseCallback;
+import com.alipay.sofa.rpc.core.util.SafeConcurrentHashMap;
 import com.alipay.sofa.rpc.message.ResponseFuture;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 基于ThreadLocal的面向业务开发者使用的上下文传递对象
@@ -44,7 +44,7 @@ public class RpcInvokeContext {
     /**
      * 自定义 header ，用完一次即删
      */
-    protected Map<String, String> customHeader = new ConcurrentHashMap<>();
+    protected Map<String, String> customHeader = new SafeConcurrentHashMap<>();
     /**
      * 用户自定义超时时间，单次调用生效
      */
@@ -68,19 +68,19 @@ public class RpcInvokeContext {
     /**
      * 自定义属性
      */
-    protected Map<String, Object> map = new ConcurrentHashMap<>();
+    protected Map<String, Object> map = new SafeConcurrentHashMap<>();
     /**
      * 请求上的透传数据
      *
      * @since 5.1.2
      */
-    protected Map<String, String> requestBaggage = BAGGAGE_ENABLE ? new ConcurrentHashMap<>() : null;
+    protected Map<String, String> requestBaggage = BAGGAGE_ENABLE ? new SafeConcurrentHashMap<>() : null;
     /**
      * 响应上的透传数据
      *
      * @since 5.1.2
      */
-    protected Map<String, String> responseBaggage = BAGGAGE_ENABLE ? new ConcurrentHashMap<>() : null;
+    protected Map<String, String> responseBaggage = BAGGAGE_ENABLE ? new SafeConcurrentHashMap<>() : null;
 
     /**
      * 得到上下文，没有则初始化
@@ -272,7 +272,7 @@ public class RpcInvokeContext {
      */
     public void putAllRequestBaggage(Map<String, String> requestBaggage) {
         if (BAGGAGE_ENABLE && requestBaggage != null) {
-            putAllToBaggage(requestBaggage,this.requestBaggage);
+            putAllToBaggage(requestBaggage, this.requestBaggage);
         }
     }
 
@@ -341,7 +341,7 @@ public class RpcInvokeContext {
      */
     public void putAllResponseBaggage(Map<String, String> responseBaggage) {
         if (BAGGAGE_ENABLE && responseBaggage != null) {
-            putAllToBaggage(responseBaggage,this.responseBaggage);
+            putAllToBaggage(responseBaggage, this.responseBaggage);
         }
     }
 
@@ -441,7 +441,7 @@ public class RpcInvokeContext {
      * @param value header value
      */
     public void addCustomHeader(String key, String value) {
-        if(key!=null&& value !=null){
+        if (key != null && value != null) {
             customHeader.put(key, value);
         }
     }

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInvokeContext.java
@@ -40,7 +40,7 @@ public class RpcInvokeContext {
      *
      * @since 5.1.2
      */
-    private static final boolean BAGGAGE_ENABLE = RpcConfigs.getBooleanValue(RpcOptions.INVOKE_BAGGAGE_ENABLE);
+    private static boolean BAGGAGE_ENABLE = RpcConfigs.getBooleanValue(RpcOptions.INVOKE_BAGGAGE_ENABLE);
     /**
      * 自定义 header ，用完一次即删
      */
@@ -226,6 +226,7 @@ public class RpcInvokeContext {
      */
     public void putRequestBaggage(String key, String value) {
         if (BAGGAGE_ENABLE && key != null && value != null) {
+
             requestBaggage.put(key, value);
         }
     }
@@ -272,7 +273,18 @@ public class RpcInvokeContext {
      */
     public void putAllRequestBaggage(Map<String, String> requestBaggage) {
         if (BAGGAGE_ENABLE && requestBaggage != null) {
-            this.requestBaggage.putAll(requestBaggage);
+            putAllToBaggage(requestBaggage,this.requestBaggage);
+        }
+    }
+
+
+    private void putAllToBaggage(Map<String, String> src, Map<String, String> dst) {
+        for (Map.Entry<String, String> entry : src.entrySet()) {
+            String value = entry.getValue();
+            String key = entry.getKey();
+            if (value != null && key != null) {
+                dst.put(key, value);
+            }
         }
     }
 
@@ -330,7 +342,7 @@ public class RpcInvokeContext {
      */
     public void putAllResponseBaggage(Map<String, String> responseBaggage) {
         if (BAGGAGE_ENABLE && responseBaggage != null) {
-            this.responseBaggage.putAll(responseBaggage);
+            putAllToBaggage(responseBaggage,this.responseBaggage);
         }
     }
 
@@ -430,7 +442,9 @@ public class RpcInvokeContext {
      * @param value header value
      */
     public void addCustomHeader(String key, String value) {
-        customHeader.put(key, value);
+        if(key!=null&& value !=null){
+            customHeader.put(key, value);
+        }
     }
 
     public void clearCustomHeader() {

--- a/core/api/src/main/java/com/alipay/sofa/rpc/core/util/SafeConcurrentHashMap.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/core/util/SafeConcurrentHashMap.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.core.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * @author zhaowang
+ * @version : SafeConcurrentHashMap.java, v 0.1 2021年12月16日 3:19 下午 zhaowang
+ */
+public class SafeConcurrentHashMap<K, V> extends ConcurrentHashMap<K, V> {
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        if (key != null && value != null) {
+            return super.putIfAbsent(key, value);
+        }
+        return get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        if (key != null && value != null) {
+            return super.put(key, value);
+        }
+        return get(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        for (Map.Entry<? extends K, ? extends V> e : m.entrySet())
+            put(e.getKey(), e.getValue());
+    }
+
+    @Override
+    public V get(Object key) {
+        if (key == null) {
+            return null;
+        }
+        return super.get(key);
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        if (key == null) {
+            return null;
+        }
+        return super.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        if (key == null) {
+            return null;
+        }
+        return super.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        if (key == null) {
+            return null;
+        }
+        return super.compute(key, remappingFunction);
+    }
+
+    @Override
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        // if value == null ,HashMap will throw NPE
+        if (key == null && value != null) {
+            return null;
+        }
+        return super.merge(key, value, remappingFunction);
+    }
+}

--- a/core/api/src/test/java/com/alipay/sofa/rpc/context/BaggageResolverTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/context/BaggageResolverTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.context;
+
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.core.util.SafeConcurrentHashMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author <a href=mailto:orezsilence@163.com>zhangchengxi</a>
+ */
+public class BaggageResolverTest {
+
+    public static final String KEY   = "key";
+    public static final String VALUE = "value";
+    private static boolean     oldEnableBaggage;
+    private static Field       enableBaggageField;
+
+    static {
+        try {
+            enableBaggageField = RpcInvokeContext.class.getDeclaredField("BAGGAGE_ENABLE");
+            enableBaggageField.setAccessible(true);
+            oldEnableBaggage = (boolean) enableBaggageField.get(null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Before
+    public void before() {
+        try {
+            enableBaggageField.set(null, true);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @After
+    public void after() {
+        try {
+            RpcInvokeContext.removeContext();
+            enableBaggageField.set(null, oldEnableBaggage);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testCarryWithRequest() {
+        SofaRequest sofaRequest = new SofaRequest();
+        RpcInvokeContext context = RpcInvokeContext.getContext();
+        context.putRequestBaggage(KEY, VALUE);
+        BaggageResolver.carryWithRequest(context, sofaRequest);
+        Object baggage = sofaRequest.getRequestProp(RemotingConstants.RPC_REQUEST_BAGGAGE);
+        assertNotNull(baggage);
+        assertEquals(HashMap.class, baggage.getClass());
+        assertEquals(VALUE, ((Map) baggage).get(KEY));
+    }
+
+    @Test
+    public void testPickupFromRequest() {
+        SofaRequest sofaRequest = new SofaRequest();
+        RpcInvokeContext context = RpcInvokeContext.getContext();
+        context.putRequestBaggage(KEY, VALUE);
+        HashMap<String, String> hashMap = new HashMap<>();
+        hashMap.put(null, "null");
+        hashMap.put(KEY, VALUE);
+        sofaRequest.addRequestProp(RemotingConstants.RPC_REQUEST_BAGGAGE, hashMap);
+        BaggageResolver.pickupFromRequest(context, sofaRequest);
+        assertEquals(VALUE, RpcInvokeContext.getContext().getAllRequestBaggage().get(KEY));
+        assertEquals(null, RpcInvokeContext.getContext().getAllRequestBaggage().get(null));
+        assertEquals(1, RpcInvokeContext.getContext().getAllRequestBaggage().size());
+        assertEquals(SafeConcurrentHashMap.class, RpcInvokeContext.getContext().getAllRequestBaggage().getClass());
+    }
+
+    @Test
+    public void testCarryWithResponse() {
+        SofaResponse sofaResponse = new SofaResponse();
+        RpcInvokeContext context = RpcInvokeContext.getContext();
+        context.putResponseBaggage(KEY, VALUE);
+        BaggageResolver.carryWithResponse(context, sofaResponse);
+        String baggage = (String) sofaResponse.getResponseProp(RemotingConstants.RPC_RESPONSE_BAGGAGE
+            + "." + KEY);
+        assertNotNull(baggage);
+        assertEquals(VALUE, baggage);
+    }
+
+    @Test
+    public void testPickupFromResponse() {
+        SofaResponse sofaResponse = new SofaResponse();
+        RpcInvokeContext context = RpcInvokeContext.getContext();
+        context.putResponseBaggage(KEY, VALUE);
+        sofaResponse.addResponseProp(RemotingConstants.RPC_RESPONSE_BAGGAGE + ".key", VALUE);
+        sofaResponse.addResponseProp(RemotingConstants.RPC_RESPONSE_BAGGAGE + ".key2", null);
+        BaggageResolver.pickupFromResponse(context, sofaResponse);
+        assertEquals(VALUE, RpcInvokeContext.getContext().getAllResponseBaggage().get(KEY));
+        assertEquals(null, RpcInvokeContext.getContext().getAllResponseBaggage().get("key2"));
+        assertEquals(1, RpcInvokeContext.getContext().getAllResponseBaggage().size());
+        assertEquals(SafeConcurrentHashMap.class, RpcInvokeContext.getContext()
+            .getAllResponseBaggage().getClass());
+    }
+
+}

--- a/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/context/RpcInvokeContextTest.java
@@ -16,9 +16,12 @@
  */
 package com.alipay.sofa.rpc.context;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -28,6 +31,38 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
  */
 public class RpcInvokeContextTest {
+
+    private static boolean oldEnableBaggage;
+    private static Field   enableBaggageField;
+
+    static {
+        try {
+            enableBaggageField = RpcInvokeContext.class.getDeclaredField("BAGGAGE_ENABLE");
+            enableBaggageField.setAccessible(true);
+            oldEnableBaggage = (boolean) enableBaggageField.get(null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Before
+    public void before() {
+        try {
+            enableBaggageField.set(null, true);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @After
+    public void after() {
+        try {
+            enableBaggageField.set(null, oldEnableBaggage);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
     @Test
     public void removeContext() throws Exception {
     }
@@ -165,4 +200,42 @@ public class RpcInvokeContextTest {
             i++;
         }
     }
+
+    @Test
+    public void testBaggageNotNull() {
+        RpcInvokeContext ctx = new RpcInvokeContext();
+        ctx.putRequestBaggage(null, "value");
+        Assert.assertTrue(isEmpty(ctx.getAllRequestBaggage()));
+        ctx.putRequestBaggage("key", null);
+        Assert.assertTrue(isEmpty(ctx.getAllRequestBaggage()));
+        Map<String, String> map = new HashMap<>();
+        map.put(null, "value");
+        map.put("key", null);
+        map.put("key1", "value");
+        ctx.putAllRequestBaggage(map);
+        Assert.assertNotNull(ctx.getAllRequestBaggage());
+        Assert.assertEquals(1, ctx.getAllRequestBaggage().size());
+        ctx.putResponseBaggage(null, "value");
+        Assert.assertTrue(isEmpty(ctx.getAllResponseBaggage()));
+        ctx.putResponseBaggage("key", null);
+        Assert.assertTrue(isEmpty(ctx.getAllResponseBaggage()));
+        ctx.putAllResponseBaggage(map);
+        Assert.assertNotNull(ctx.getAllResponseBaggage());
+        Assert.assertEquals(1, ctx.getAllResponseBaggage().size());
+    }
+
+    private boolean isEmpty(Map<String, String> allResponseBaggage) {
+        return allResponseBaggage == null || allResponseBaggage.size() == 0;
+    }
+
+    @Test
+    public void testPutCustomHeader() {
+        RpcInvokeContext ctx = new RpcInvokeContext();
+        ctx.addCustomHeader(null, "value");
+        ctx.addCustomHeader("key", null);
+        ctx.addCustomHeader("key1", "value");
+        Assert.assertEquals(1, ctx.getCustomHeader().size());
+        Assert.assertEquals("value", ctx.getCustomHeader().get("key1"));
+    }
+
 }

--- a/core/api/src/test/java/com/alipay/sofa/rpc/core/util/SafeConcurrentHashMapTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/core/util/SafeConcurrentHashMapTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.core.util;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+/**
+ * @author <a href=mailto:orezsilence@163.com>zhangchengxi</a>
+ */
+public class SafeConcurrentHashMapTest {
+    public static final String    KEY   = "key";
+    public static final String    VALUE = "value";
+    private SafeConcurrentHashMap map   = new SafeConcurrentHashMap();
+
+    @Before
+    public void before() {
+        map = new SafeConcurrentHashMap();
+        map.put(KEY, VALUE);
+    }
+
+    @Test
+    public void testPut() {
+        SafeConcurrentHashMap<Object, Object> map = new SafeConcurrentHashMap<>();
+        Assert.assertNull(map.put(null, null));
+        Assert.assertNull(map.put(null, "value"));
+        Assert.assertNull(map.put("key", null));
+        Assert.assertEquals(0, map.size());
+        Assert.assertNull(map.put("key", "value"));
+        Assert.assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testPutIfAbsent() {
+        SafeConcurrentHashMap<Object, Object> map = new SafeConcurrentHashMap<>();
+        Assert.assertNull(map.putIfAbsent(null, null));
+        Assert.assertNull(map.putIfAbsent(null, "value"));
+        Assert.assertNull(map.putIfAbsent("key", null));
+        Assert.assertEquals(0, map.size());
+        Assert.assertNull(map.putIfAbsent("key", "value"));
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals("value", map.get("key"));
+        Assert.assertEquals("value", map.putIfAbsent("key", "anotherValue"));
+    }
+
+    @Test
+    public void testPutAll() {
+        HashMap<Object, Object> hashMap = new HashMap<>();
+        hashMap.put(null, "value");
+        hashMap.put("key", null);
+        hashMap.put("key1", "value");
+        Assert.assertEquals(3, hashMap.size());
+        SafeConcurrentHashMap<Object, Object> safeConcurrentHashMap = new SafeConcurrentHashMap<>();
+        safeConcurrentHashMap.putAll(hashMap);
+        Assert.assertEquals(1, safeConcurrentHashMap.size());
+        Assert.assertEquals("value", safeConcurrentHashMap.get("key1"));
+    }
+
+    @Test
+    public void testGet() {
+        Assert.assertNull(map.get(null));
+        Assert.assertEquals(VALUE, map.get(KEY));
+    }
+
+    @Test
+    public void testComputeIfAbsent() {
+        Assert.assertEquals(null, map.computeIfAbsent(null, key -> ""));
+        Assert.assertEquals(VALUE, map.computeIfAbsent(KEY, key -> ""));
+        Assert.assertEquals(VALUE, map.get(KEY));
+    }
+
+    @Test
+    public void testComputeIfPresent() {
+        Assert.assertEquals(VALUE, map.get(KEY));
+        Assert.assertEquals(null, map.computeIfAbsent(null, key -> ""));
+        Assert.assertEquals("", map.computeIfPresent(KEY, (key, value) -> ""));
+        Assert.assertEquals("", map.get(KEY));
+    }
+
+    @Test
+    public void testCompute() {
+        Assert.assertEquals(VALUE, map.get(KEY));
+        Assert.assertEquals(null, map.compute(null, (key, value) -> ""));
+        Assert.assertEquals(VALUE, map.get(KEY));
+    }
+
+    @Test
+    public void testMerge() {
+        Assert.assertEquals(VALUE, map.get(KEY));
+        try {
+            map.merge(null, null, (key, value) -> "");
+            Assert.fail();
+        } catch (NullPointerException npe) {
+            //ignore
+        }
+        Assert.assertNull(map.merge(null, "value", (key, value) -> ""));
+        Assert.assertEquals("value1", map.merge("key1", "value1", (v1, v2) -> v1 + "" + v2));
+        Assert.assertEquals(VALUE + VALUE, map.merge(KEY, VALUE, (v1, v2) -> v1 + "" + v2));
+    }
+}


### PR DESCRIPTION
### Motivation:

To keep compatibility between old version， I use  `HashMap` as transport Baggage type. 
If users using `com.alipay.sofa.rpc.context.RpcInvokeContext#getAllRequestBaggage` to get the baggage map.They may put null to it ,and they will get NPE in newer version .So I add a wrapper class out of baggage map.
