### PR TITLE
Add DomainRegistry to support direct url 

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/client/ProviderInfo.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/client/ProviderInfo.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @author <a href=mailto:zhanggeng.zg@antfin.com>GengZhang</a>
  */
-public class ProviderInfo implements Serializable {
+public class ProviderInfo implements Serializable, Cloneable {
 
     private static final long                             serialVersionUID = -6438690329875954051L;
 
@@ -507,5 +507,22 @@ public class ProviderInfo implements Serializable {
     public String getAttr(String key) {
         String val = StringUtils.toString(dynamicAttrs.get(key));
         return val == null ? staticAttrs.get(key) : val;
+    }
+
+    @Override
+    public ProviderInfo clone() {
+        ProviderInfo providerInfo = new ProviderInfo();
+        providerInfo.originUrl = this.originUrl;
+        providerInfo.protocolType = this.protocolType;
+        providerInfo.host = this.host;
+        providerInfo.port = this.port;
+        providerInfo.path = this.path;
+        providerInfo.serializationType = this.serializationType;
+        providerInfo.rpcVersion = this.rpcVersion;
+        providerInfo.weight = this.weight;
+        providerInfo.status = this.status;
+        providerInfo.staticAttrs.putAll(this.staticAttrs);
+        providerInfo.dynamicAttrs.putAll(this.dynamicAttrs);
+        return providerInfo;
     }
 }

--- a/registry/registry-local/pom.xml
+++ b/registry/registry-local/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/registry/registry-local/src/main/java/com/alipay/sofa/rpc/registry/local/DomainRegistry.java
+++ b/registry/registry-local/src/main/java/com/alipay/sofa/rpc/registry/local/DomainRegistry.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.local;
+
+import com.alipay.sofa.rpc.client.ProviderGroup;
+import com.alipay.sofa.rpc.client.ProviderHelper;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.client.ProviderInfoAttrs;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.common.struct.ScheduledService;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.RegistryConfig;
+import com.alipay.sofa.rpc.ext.Extension;
+import com.alipay.sofa.rpc.log.Logger;
+import com.alipay.sofa.rpc.log.LoggerFactory;
+import com.alipay.sofa.rpc.registry.Registry;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author zhaowang
+ * @version : DomainRegistry.java, v 0.1 2022年05月24日 5:15 下午 zhaowang
+ */
+@Extension("local")
+public class DomainRegistry extends Registry {
+
+    /**
+     * Logger
+     */
+    private static final Logger                 LOGGER          = LoggerFactory.getLogger(DomainRegistry.class);
+
+    protected Map<String, List<ConsumerConfig>> notifyListeners = new ConcurrentHashMap<String, List<ConsumerConfig>>();
+
+    protected Map<String, List<ProviderInfo>>   domainCache     = new ConcurrentHashMap<String, List<ProviderInfo>>();
+    /**
+     * 扫描周期，毫秒
+     */
+    protected int                               scanPeriod      = 10000;
+
+    /**
+     * 定时加载
+     */
+    protected ScheduledService                  scheduledExecutorService;
+
+    /**
+     * 注册中心配置
+     *
+     * @param registryConfig 注册中心配置
+     */
+    protected DomainRegistry(RegistryConfig registryConfig) {
+        super(registryConfig);
+    }
+
+    @Override
+    public void init() {
+        this.scanPeriod = CommonUtils.parseInt(registryConfig.getParameter("registry.domain.scan.period"),
+            scanPeriod);
+
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    refreshDomain();
+                    notifyListener();
+                } catch (Throwable e) {
+                    LOGGER.error(e.getMessage(), e);
+                }
+            }
+        };
+
+        scheduledExecutorService = new ScheduledService("DomainRegistry-Back-Load",
+            ScheduledService.MODE_FIXEDDELAY,
+            task, //定时load任务
+            scanPeriod, // 延迟一个周期
+            scanPeriod, // 一个周期循环
+            TimeUnit.MILLISECONDS
+                ).start();
+
+    }
+
+    protected void refreshDomain() {
+        Set<String> keySet = new HashSet<>();
+        for (Map.Entry<String, List<ConsumerConfig>> entry : notifyListeners.entrySet()) {
+            String directUrl = entry.getKey();
+            String[] providerStrs = StringUtils.splitWithCommaOrSemicolon(directUrl);
+            keySet.addAll(Arrays.asList(providerStrs));
+        }
+
+        for (String directUrl : keySet) {
+            ProviderInfo providerInfo = ProviderHelper.toProviderInfo(directUrl);
+            List<ProviderInfo> result = directUrl2IpUrl(providerInfo);
+            domainCache.put(directUrl, result);
+        }
+    }
+
+    protected void notifyListener() {
+        for (Map.Entry<String, List<ConsumerConfig>> entry : notifyListeners.entrySet()) {
+            String directUrls = entry.getKey();
+            String[] providerStrs = StringUtils.splitWithCommaOrSemicolon(directUrls);
+            List<ProviderInfo> result = new ArrayList<>();
+            for (String providerStr : providerStrs) {
+                List<ProviderInfo> providerInfos = domainCache.get(providerStr);
+                result.addAll(providerInfos);
+            }
+            List<ConsumerConfig> configs = entry.getValue();
+            for (ConsumerConfig config : configs) {
+                ProviderGroup providerGroup = new ProviderGroup(RpcConstants.ADDRESS_DIRECT_GROUP, result);
+                config.getProviderInfoListener().updateProviders(providerGroup);
+            }
+        }
+    }
+
+    private ProviderGroup getDirectGroup(String directUrl) {
+        List<ProviderInfo> tmpProviderInfoList = new ArrayList<ProviderInfo>();
+        String[] providerStrs = StringUtils.splitWithCommaOrSemicolon(directUrl);
+        for (String providerStr : providerStrs) {
+            if (DomainRegistryHelper.isDomain(providerStr)) {
+                List<ProviderInfo> providerInfos = resolveDomain(providerStr);
+                tmpProviderInfoList.addAll(providerInfos);
+            } else {
+                ProviderInfo providerInfo = ProviderHelper.toProviderInfo(providerStr);
+                if (providerInfo.getStaticAttr(ProviderInfoAttrs.ATTR_SOURCE) == null) {
+                    providerInfo.setStaticAttr(ProviderInfoAttrs.ATTR_SOURCE, "direct");
+                }
+                tmpProviderInfoList.add(providerInfo);
+            }
+        }
+
+        return new ProviderGroup(RpcConstants.ADDRESS_DIRECT_GROUP, tmpProviderInfoList);
+    }
+
+    protected List<ProviderInfo> resolveDomain(String directUrl) {
+        List<ProviderInfo> providerInfos = domainCache.get(directUrl);
+        if (providerInfos != null) {
+            return providerInfos;
+        }
+        ProviderInfo providerInfo = ProviderHelper.toProviderInfo(directUrl);
+        List<ProviderInfo> result = directUrl2IpUrl(providerInfo);
+        domainCache.put(directUrl, result);
+        return result;
+    }
+
+    protected List<ProviderInfo> directUrl2IpUrl(ProviderInfo providerInfo) {
+        try {
+            List<ProviderInfo> result = new ArrayList<>();
+            String originHost = providerInfo.getHost();
+            String originUrl = providerInfo.getOriginUrl();
+            InetAddress[] addresses = InetAddress.getAllByName(originHost);
+            if (addresses != null && addresses.length > 0) {
+                String firstHost = addresses[0].getHostAddress();
+                if (firstHost == null || firstHost.equals(providerInfo.getHost())) {
+                    result.add(providerInfo);
+                    return result;
+                } else if (StringUtils.isNotBlank(originUrl)) {
+                    for (InetAddress address : addresses) {
+                        String newHost = address.getHostAddress();
+                        ProviderInfo tmp = providerInfo.clone();
+                        String newUrl = originUrl.replace(originHost, newHost);
+                        tmp.setOriginUrl(newUrl);
+                        tmp.setHost(newHost);
+                        result.add(tmp);
+                    }
+                    return result;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("directUrl2IpUrl error", e);
+        }
+
+        List<ProviderInfo> providerInfos = new ArrayList<>();
+        providerInfos.add(providerInfo);
+        return providerInfos;
+
+    }
+
+    @Override
+    public boolean start() {
+        return false;
+    }
+
+    @Override
+    public void register(ProviderConfig config) {
+        throw new UnsupportedOperationException("DomainRegistry not support register providerConfig:" +
+            config.getInterfaceId());
+    }
+
+    @Override
+    public void unRegister(ProviderConfig config) {
+        throw new UnsupportedOperationException("DomainRegistry not support unRegister providerConfig:" +
+            config.getInterfaceId());
+    }
+
+    @Override
+    public void batchUnRegister(List<ProviderConfig> configs) {
+        throw new UnsupportedOperationException("DomainRegistry not support batchUnRegister providerConfigs");
+    }
+
+    @Override
+    public List<ProviderGroup> subscribe(ConsumerConfig config) {
+        String directUrl = config.getDirectUrl();
+        if (StringUtils.isNotBlank(directUrl)) {
+            List<ConsumerConfig> listeners = notifyListeners.get(directUrl);
+            if (listeners == null) {
+                notifyListeners.putIfAbsent(directUrl, new CopyOnWriteArrayList<>());
+                listeners = notifyListeners.get(directUrl);
+            }
+            listeners.add(config);
+            ProviderGroup directGroup = getDirectGroup(directUrl);
+            ArrayList<ProviderGroup> providerGroups = new ArrayList<>();
+            providerGroups.add(directGroup);
+            return providerGroups;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void unSubscribe(ConsumerConfig consumerConfig) {
+        String directUrl = consumerConfig.getDirectUrl();
+        notifyListeners.remove(directUrl);
+    }
+
+    @Override
+    public void batchUnSubscribe(List<ConsumerConfig> configs) {
+        for (ConsumerConfig config : configs) {
+            unSubscribe(config);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        notifyListeners.clear();
+        domainCache.clear();
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdown();
+        }
+    }
+
+}

--- a/registry/registry-local/src/main/java/com/alipay/sofa/rpc/registry/local/DomainRegistryHelper.java
+++ b/registry/registry-local/src/main/java/com/alipay/sofa/rpc/registry/local/DomainRegistryHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.local;
+
+import com.alipay.sofa.rpc.client.ProviderHelper;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.google.common.net.InetAddresses;
+
+/**
+ * @author zhaowang
+ * @version : DomainRegistryHelper.java, v 0.1 2022年05月24日 5:26 下午 zhaowang
+ */
+public class DomainRegistryHelper {
+
+    /**
+     * bolt://taobao.com:80?a=b   true
+     * taobao.com:80?a=b          true
+     *
+     * @param url
+     * @return
+     */
+    public static boolean isDomain(String url) {
+        String host = getDomain(url);
+        if (StringUtils.isEmpty(host)) {
+            return false;
+        } else {
+            return !isIp(host);
+        }
+    }
+
+    private static boolean isIp(String host) {
+        return InetAddresses.isInetAddress(host);
+    }
+
+    public static String getDomain(String url) {
+        ProviderInfo providerInfo = ProviderHelper.toProviderInfo(url);
+        return providerInfo.getHost();
+    }
+}

--- a/registry/registry-local/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.registry.Registry
+++ b/registry/registry-local/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.registry.Registry
@@ -1,1 +1,2 @@
 local=com.alipay.sofa.rpc.registry.local.LocalRegistry
+domain=com.alipay.sofa.rpc.registry.local.DomainRegistry

--- a/registry/registry-local/src/test/java/com/alipay/sofa/rpc/registry/local/DomainRegistryHelperTest.java
+++ b/registry/registry-local/src/test/java/com/alipay/sofa/rpc/registry/local/DomainRegistryHelperTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.local;
+
+import org.junit.Test;
+
+import static com.alipay.sofa.rpc.registry.local.DomainRegistryHelper.getDomain;
+import static com.alipay.sofa.rpc.registry.local.DomainRegistryHelper.isDomain;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href=mailto:orezsilence@163.com>zhangchengxi</a>
+ */
+public class DomainRegistryHelperTest {
+
+    @Test
+    public void testIsDomain() {
+        assertTrue(isDomain("bolt://alipay.com:80?a=b"));
+        assertTrue(isDomain("alipay.com:80?a=b"));
+        assertTrue(isDomain("bolt://alipay.com:80"));
+        assertTrue(isDomain("alipay.com:80"));
+        assertTrue(isDomain("bolt://alipay?a=b"));
+        assertTrue(isDomain("alipay"));
+        assertTrue(isDomain("sofagw-pool"));
+
+        assertFalse(isDomain("bolt://1.1.1.1:80?a=b"));
+        assertFalse(isDomain("1.1.1.1:80?a=b"));
+        assertFalse(isDomain("bolt://1.1.1.1:80"));
+        assertFalse(isDomain("1.1.1.1:80"));
+        assertFalse(isDomain("1.1.1.1"));
+
+        //todo now we do not support ipv6
+        //        assertFalse(isDomain("bolt://FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF#12200?a=b"));
+        //        assertFalse(isDomain("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF#12200?a=b"));
+        //        assertFalse(isDomain("bolt://FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF#12200"));
+        //        assertFalse(isDomain("bolt://FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF?a=b"));
+        //        assertFalse(isDomain("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"));
+    }
+
+    @Test
+    public void testGetDomain() {
+        assertEquals("alipay.com", getDomain("bolt://alipay.com:80?a=b"));
+        assertEquals("alipay.com", getDomain("alipay.com:80?a=b"));
+        assertEquals("alipay.com", getDomain("bolt://alipay.com:80"));
+        assertEquals("alipay.com", getDomain("alipay.com:80"));
+        assertEquals("alipay", getDomain("bolt://alipay?a=b"));
+        assertEquals("alipay", getDomain("alipay"));
+        assertEquals("sofagw-pool", getDomain("sofagw-pool"));
+
+        assertEquals("1.1.1.1", getDomain("bolt://1.1.1.1:80?a=b"));
+        assertEquals("1.1.1.1", getDomain("1.1.1.1:80?a=b"));
+        assertEquals("1.1.1.1", getDomain("bolt://1.1.1.1:80"));
+        assertEquals("1.1.1.1", getDomain("1.1.1.1:80"));
+        assertEquals("1.1.1.1", getDomain("1.1.1.1"));
+    }
+}

--- a/registry/registry-local/src/test/java/com/alipay/sofa/rpc/registry/local/DomainRegistryTest.java
+++ b/registry/registry-local/src/test/java/com/alipay/sofa/rpc/registry/local/DomainRegistryTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.local;
+
+import com.alipay.sofa.rpc.client.ProviderGroup;
+import com.alipay.sofa.rpc.client.ProviderHelper;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.RegistryConfig;
+import com.alipay.sofa.rpc.listener.ProviderInfoListener;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href=mailto:orezsilence@163.com>zhangchengxi</a>
+ */
+public class DomainRegistryTest {
+
+    private DomainRegistry domainRegistry;
+
+    @Before
+    public void before() {
+        domainRegistry = new DomainRegistry(new RegistryConfig());
+    }
+
+    @After
+    public void after() {
+        domainRegistry.destroy();
+    }
+
+    @Test
+    public void testInit() {
+        DomainRegistry domainRegistry = new DomainRegistry(new RegistryConfig());
+        assertNull(domainRegistry.scheduledExecutorService);
+        domainRegistry.init();
+        assertTrue(domainRegistry.scheduledExecutorService.isStarted());
+    }
+
+    @Test
+    public void testDirectUrl2IpUrl() {
+        ProviderInfo providerInfo = ProviderHelper.toProviderInfo("bolt://alipay.com:12200");
+        List<ProviderInfo> providerInfos = domainRegistry.directUrl2IpUrl(providerInfo);
+        assertTrue(providerInfos.size() > 0);
+        String host = providerInfos.get(0).getHost();
+        assertNotEquals("alipay.net", host);
+        assertFalse(DomainRegistryHelper.isDomain(host));
+
+        ProviderInfo notExist = ProviderHelper.toProviderInfo("bolt://notexist:12200");
+        providerInfos = domainRegistry.directUrl2IpUrl(notExist);
+        assertEquals(1, providerInfos.size());
+        host = providerInfos.get(0).getHost();
+        assertEquals("notexist", host);
+
+        ProviderInfo ipProviderInfo = ProviderHelper.toProviderInfo("bolt://127.0.0.1:12200");
+        providerInfos = domainRegistry.directUrl2IpUrl(ipProviderInfo);
+        assertEquals(1, providerInfos.size());
+        host = providerInfos.get(0).getHost();
+        assertEquals("127.0.0.1", host);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRegister() {
+        domainRegistry.register(new ProviderConfig<>());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnRegister() {
+        domainRegistry.unRegister(new ProviderConfig<>());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testBatchUnRegister() {
+        domainRegistry.batchUnRegister(Collections.singletonList(new ProviderConfig<>()));
+    }
+
+    @Test
+    public void testSubscribe() {
+        ConsumerConfig<Object> consumerConfig = new ConsumerConfig<>();
+        String directUrl = "bolt://alipay.com";
+        consumerConfig.setDirectUrl(directUrl);
+        List<ProviderGroup> providerGroups = domainRegistry.subscribe(consumerConfig);
+        assertTrue(domainRegistry.notifyListeners.containsKey(directUrl));
+        assertSame(consumerConfig, domainRegistry.notifyListeners.get(directUrl).get(0));
+
+        assertEquals(1, providerGroups.size());
+        ProviderGroup providerGroup = providerGroups.get(0);
+        assertEquals(RpcConstants.ADDRESS_DIRECT_GROUP, providerGroup.getName());
+
+
+        ConsumerConfig<Object> notDirect = new ConsumerConfig<>();
+        notDirect.setDirectUrl("");
+        domainRegistry.subscribe(notDirect);
+        assertFalse(domainRegistry.notifyListeners.containsKey(""));
+
+        ConsumerConfig<Object> ipConfig = new ConsumerConfig<>();
+        String ip = "bolt://127.0.0.1";
+        ipConfig.setDirectUrl(ip);
+        List<ProviderGroup> ipProviderGroup = domainRegistry.subscribe(ipConfig);
+        assertTrue(domainRegistry.notifyListeners.containsKey(directUrl));
+        assertSame(consumerConfig, domainRegistry.notifyListeners.get(directUrl).get(0));
+
+        assertEquals(1, ipProviderGroup.size());
+        ProviderGroup ipGroup = ipProviderGroup.get(0);
+        assertEquals(RpcConstants.ADDRESS_DIRECT_GROUP, ipGroup.getName());
+        assertEquals(1, ipGroup.getProviderInfos().size());
+        assertEquals("127.0.0.1", ipGroup.getProviderInfos().get(0).getHost());
+    }
+
+    @Test
+    public void testUnSubscribe() {
+        ConsumerConfig<Object> consumerConfig = new ConsumerConfig<>();
+        String directUrl = "bolt://alipay.com";
+        consumerConfig.setDirectUrl(directUrl);
+        List<ProviderGroup> providerGroups = domainRegistry.subscribe(consumerConfig);
+        assertTrue(domainRegistry.notifyListeners.containsKey(directUrl));
+        assertSame(consumerConfig, domainRegistry.notifyListeners.get(directUrl).get(0));
+
+        domainRegistry.unSubscribe(consumerConfig);
+        assertFalse(domainRegistry.notifyListeners.containsKey(directUrl));
+    }
+
+    @Test
+    public void testBatchUnSubscribe() {
+        ConsumerConfig<Object> config1 = new ConsumerConfig<>();
+        String direct1 = "2";
+        config1.setDirectUrl(direct1);
+
+        ConsumerConfig<Object> config2 = new ConsumerConfig<>();
+        String direct2 = "1";
+        config2.setDirectUrl(direct2);
+
+        domainRegistry.subscribe(config1);
+        domainRegistry.subscribe(config2);
+
+        assertTrue(domainRegistry.notifyListeners.containsKey(direct1));
+        assertTrue(domainRegistry.notifyListeners.containsKey(direct2));
+
+        List<ConsumerConfig> consumerConfigs = Arrays.asList(config1, config2);
+        domainRegistry.batchUnSubscribe(consumerConfigs);
+        assertFalse(domainRegistry.notifyListeners.containsKey(direct1));
+        assertFalse(domainRegistry.notifyListeners.containsKey(direct2));
+    }
+
+    @Test
+    public void testDestroy() {
+        domainRegistry.init();
+        ConsumerConfig<Object> config1 = new ConsumerConfig<>();
+        String direct1 = "2";
+        config1.setDirectUrl(direct1);
+        domainRegistry.subscribe(config1);
+
+        assertTrue(domainRegistry.scheduledExecutorService.isStarted());
+        assertTrue(domainRegistry.notifyListeners.containsKey(direct1));
+        domainRegistry.destroy();
+        assertFalse(domainRegistry.scheduledExecutorService.isStarted());
+        assertEquals(0, domainRegistry.notifyListeners.size());
+    }
+
+    @Test
+    public void testRefreshDomain() {
+        ConsumerConfig<Object> consumerConfig = new ConsumerConfig<>();
+        String directUrl1 = "bolt://alipay.com";
+        String directUrl2 = "bolt://taobao.com";
+        String directUrl = directUrl1 + ";" + directUrl2;
+        consumerConfig.setDirectUrl(directUrl);
+        domainRegistry.subscribe(consumerConfig);
+
+        assertTrue(domainRegistry.notifyListeners.containsKey(directUrl));
+        domainRegistry.refreshDomain();
+
+        assertTrue(domainRegistry.domainCache.containsKey(directUrl1));
+        assertTrue(domainRegistry.domainCache.containsKey(directUrl2));
+    }
+
+    @Test
+    public void testNotifyListener() {
+        ConsumerConfig<Object> consumerConfig = new ConsumerConfig<>();
+        String directUrl1 = "bolt://alipay.com";
+        String directUrl2 = "bolt://taobao.com";
+        String directUrl = directUrl1 + ";" + directUrl2;
+        consumerConfig.setDirectUrl(directUrl);
+        MockProviderInfoListener mockProviderInfoListener = new MockProviderInfoListener();
+        consumerConfig.setProviderInfoListener(mockProviderInfoListener);
+
+
+        domainRegistry.subscribe(consumerConfig);
+
+        assertTrue(domainRegistry.notifyListeners.containsKey(directUrl));
+        domainRegistry.refreshDomain();
+
+        assertTrue(domainRegistry.domainCache.containsKey(directUrl1));
+        assertTrue(domainRegistry.domainCache.containsKey(directUrl2));
+
+        domainRegistry.notifyListener();
+
+        Map<String, List<ProviderInfo>> data = mockProviderInfoListener.getData();
+        assertEquals(1, data.size());
+        assertTrue(data.containsKey(RpcConstants.ADDRESS_DIRECT_GROUP));
+        List<ProviderInfo> providerInfo = data.get(RpcConstants.ADDRESS_DIRECT_GROUP);
+        assertTrue(providerInfo.size() > 1);
+    }
+
+    @Test
+    public void testResolveDomain() {
+        String mockKey = "mock";
+        List<ProviderInfo> value = new ArrayList<>();
+        domainRegistry.domainCache.put(mockKey, value);
+        assertSame(value, domainRegistry.resolveDomain(mockKey));
+
+        String local = "127.0.0.1";
+        List<ProviderInfo> actual = domainRegistry.resolveDomain(local);
+        assertEquals(1, actual.size());
+        assertEquals(local, actual.get(0).getHost());
+    }
+
+    private static class MockProviderInfoListener implements ProviderInfoListener {
+
+        ConcurrentHashMap<String, List<ProviderInfo>> ps = new ConcurrentHashMap();
+
+        private CountDownLatch                        countDownLatch;
+
+        public void setCountDownLatch(CountDownLatch countDownLatch) {
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void addProvider(ProviderGroup providerGroup) {
+            ps.put(providerGroup.getName(), providerGroup.getProviderInfos());
+        }
+
+        @Override
+        public void removeProvider(ProviderGroup providerGroup) {
+            ps.remove(providerGroup.getName());
+        }
+
+        @Override
+        public void updateProviders(ProviderGroup providerGroup) {
+            ps.clear();
+            ps.put(providerGroup.getName(), providerGroup.getProviderInfos());
+            if (countDownLatch != null) {
+                countDownLatch.countDown();
+            }
+        }
+
+        @Override
+        public void updateAllProviders(List<ProviderGroup> providerGroups) {
+            ps.clear();
+            for (ProviderGroup providerGroup : providerGroups) {
+                ps.put(providerGroup.getName(), providerGroup.getProviderInfos());
+            }
+        }
+
+        public Map<String, List<ProviderInfo>> getData() {
+            return ps;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation:
When we set domain as a directurl, the ip behind the domain will not change, even if the actual ip is changed. 

### Modification:

Add DomainRegistry to check  if the ip behind the domain is changed. If so , it will  notify address holder the latest ip address.

