### PR TITLE
Bump netty from 4.1.44.Final to 4.1.77.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -13,7 +13,7 @@
         <revision>5.8.5</revision>
         <javassist.version>3.20.0-GA</javassist.version>
         <bytebuddy.version>1.9.8</bytebuddy.version>
-        <netty.version>4.1.44.Final</netty.version>
+        <netty.version>4.1.77.Final</netty.version>
         <!-- 3rd extends libs -->
         <servlet.version>2.5</servlet.version>
         <resteasy.version>3.6.3.Final</resteasy.version>


### PR DESCRIPTION
### Motivation:

see: [https://netty.io/news/index.html](https://netty.io/news/index.html)

### Modification:

netty version

### Result:



