### PR TITLE
add timeout to sofaRequest

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
@@ -604,7 +604,6 @@ public abstract class AbstractCluster extends Cluster {
             checkProviderVersion(providerInfo, request); // 根据服务端版本特殊处理
             String invokeType = request.getInvokeType();
             int timeout = resolveTimeout(request, consumerConfig, providerInfo);
-
             SofaResponse response = null;
             // 同步调用
             if (RpcConstants.INVOKER_TYPE_SYNC.equals(invokeType)) {
@@ -701,7 +700,9 @@ public abstract class AbstractCluster extends Cluster {
             }
 
             if (DynamicHelper.isNotDefault(dynamicTimeout) && StringUtils.isNotBlank(dynamicTimeout)) {
-                return Integer.parseInt(dynamicTimeout);
+                int timeout = Integer.parseInt(dynamicTimeout);
+                request.setTimeout(timeout);
+                return timeout;
             }
         }
         // 先去调用级别配置
@@ -718,6 +719,7 @@ public abstract class AbstractCluster extends Cluster {
                 }
             }
         }
+        request.setTimeout(timeout);
         return timeout;
     }
 

--- a/core-impl/client/src/test/java/com/alipay/sofa/rpc/client/AbstractClusterTest.java
+++ b/core-impl/client/src/test/java/com/alipay/sofa/rpc/client/AbstractClusterTest.java
@@ -23,8 +23,11 @@ import com.alipay.sofa.rpc.core.exception.SofaRpcException;
 import com.alipay.sofa.rpc.core.request.SofaRequest;
 import com.alipay.sofa.rpc.core.response.SofaResponse;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,10 +36,12 @@ import java.util.List;
  */
 public class AbstractClusterTest {
 
-    @Test
-    public void testDestroyWithDestroyHook() {
+    private static AbstractCluster abstractCluster;
+
+    @BeforeClass
+    public static void beforeClass() {
         ConsumerConfig consumerConfig = new ConsumerConfig().setProtocol("test")
-                .setBootstrap("test");
+            .setBootstrap("test");
         ConsumerBootstrap consumerBootstrap = new ConsumerBootstrap(consumerConfig) {
             @Override
             public Object refer() {
@@ -68,12 +73,16 @@ public class AbstractClusterTest {
                 return false;
             }
         };
-        AbstractCluster abstractCluster = new AbstractCluster(consumerBootstrap) {
+        abstractCluster = new AbstractCluster(consumerBootstrap) {
             @Override
             protected SofaResponse doInvoke(SofaRequest msg) throws SofaRpcException {
                 return null;
             }
         };
+    }
+
+    @Test
+    public void testDestroyWithDestroyHook() {
         List<String> hookActionResult = new ArrayList<>(2);
         Destroyable.DestroyHook destroyHook = new Destroyable.DestroyHook() {
             @Override
@@ -90,5 +99,41 @@ public class AbstractClusterTest {
         Assert.assertEquals(2, hookActionResult.size());
         Assert.assertEquals("preDestroy", hookActionResult.get(0));
         Assert.assertEquals("postDestroy", hookActionResult.get(1));
+    }
+
+    @Test
+    public void testResolveTimeout() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        SofaRequest sofaRequest = new SofaRequest();
+        ConsumerConfig consumerConfig = new ConsumerConfig();
+        ProviderInfo providerInfo = new ProviderInfo();
+        Method resolveTimeout = AbstractCluster.class.getDeclaredMethod("resolveTimeout", SofaRequest.class,
+            ConsumerConfig.class, ProviderInfo.class);
+        resolveTimeout.setAccessible(true);
+
+        Integer defaultTimeout = (Integer) resolveTimeout.invoke(abstractCluster, sofaRequest, consumerConfig,
+            providerInfo);
+        Assert.assertTrue(defaultTimeout == 3000);
+        Assert.assertEquals(sofaRequest.getTimeout(), defaultTimeout);
+        sofaRequest.setTimeout(null);
+
+        providerInfo.setStaticAttr(ProviderInfoAttrs.ATTR_TIMEOUT, "5000");
+        Integer providerTimeout = (Integer) resolveTimeout.invoke(abstractCluster, sofaRequest, consumerConfig,
+            providerInfo);
+        Assert.assertTrue(providerTimeout == 5000);
+        Assert.assertEquals(sofaRequest.getTimeout(), providerTimeout);
+        sofaRequest.setTimeout(null);
+
+        consumerConfig.setTimeout(2000);
+        Integer consumerTimeout = (Integer) resolveTimeout.invoke(abstractCluster, sofaRequest, consumerConfig,
+            providerInfo);
+        Assert.assertTrue(consumerTimeout == 2000);
+        Assert.assertEquals(sofaRequest.getTimeout(), consumerTimeout);
+
+        sofaRequest.setTimeout(1000);
+        Integer invokeTimeout = (Integer) resolveTimeout.invoke(abstractCluster, sofaRequest, consumerConfig,
+            providerInfo);
+        Assert.assertTrue(invokeTimeout == 1000);
+        Assert.assertEquals(sofaRequest.getTimeout(), invokeTimeout);
+
     }
 }


### PR DESCRIPTION
Before timeout only set in `com.alipay.remoting.rpc.protocol.RpcRequestCommand` on bolt, now add timeout to `com.alipay.sofa.rpc.core.request.SofaRequest` when resolveTimeout.