### PR TITLE
improve efficiency of list difference

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AllConnectConnectionHolder.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AllConnectConnectionHolder.java
@@ -21,9 +21,9 @@ import com.alipay.sofa.rpc.common.RpcConfigs;
 import com.alipay.sofa.rpc.common.RpcConstants;
 import com.alipay.sofa.rpc.common.RpcOptions;
 import com.alipay.sofa.rpc.common.struct.ConcurrentHashSet;
-import com.alipay.sofa.rpc.common.struct.ListDifference;
 import com.alipay.sofa.rpc.common.struct.NamedThreadFactory;
 import com.alipay.sofa.rpc.common.struct.ScheduledService;
+import com.alipay.sofa.rpc.common.struct.SetDifference;
 import com.alipay.sofa.rpc.common.utils.CommonUtils;
 import com.alipay.sofa.rpc.common.utils.ExceptionUtils;
 import com.alipay.sofa.rpc.common.utils.NetUtils;
@@ -379,10 +379,10 @@ public class AllConnectConnectionHolder extends ConnectionHolder {
             } else {
                 Collection<ProviderInfo> nowall = currentProviderList();
                 List<ProviderInfo> oldAllP = providerGroup.getProviderInfos();
-                List<ProviderInfo> nowAllP = new ArrayList<ProviderInfo>(nowall);// 当前全部
+                Set<ProviderInfo> nowAllP = new HashSet<ProviderInfo>(nowall);// 当前全部
 
                 // 比较当前的和最新的
-                ListDifference<ProviderInfo> diff = new ListDifference<ProviderInfo>(oldAllP, nowAllP);
+                SetDifference<ProviderInfo> diff = new SetDifference<ProviderInfo>(new HashSet<>(oldAllP), nowAllP);
                 List<ProviderInfo> needAdd = diff.getOnlyOnLeft(); // 需要新建
                 List<ProviderInfo> needDelete = diff.getOnlyOnRight(); // 需要删掉
                 if (!needAdd.isEmpty()) {

--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -27,16 +27,6 @@
             <groupId>com.alibaba</groupId>
             <artifactId>transmittable-thread-local</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     
     <build>

--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -27,6 +27,16 @@
             <groupId>com.alibaba</groupId>
             <artifactId>transmittable-thread-local</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/core/api/src/test/java/com/alipay/sofa/rpc/bench/CollectionDifferenceBenchMarkTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/bench/CollectionDifferenceBenchMarkTest.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2022 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.rpc.bench;
 

--- a/core/api/src/test/java/com/alipay/sofa/rpc/bench/CollectionDifferenceBenchMarkTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/bench/CollectionDifferenceBenchMarkTest.java
@@ -1,0 +1,125 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.sofa.rpc.bench;
+
+import com.alipay.sofa.rpc.client.ProviderHelper;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.struct.ListDifference;
+import com.alipay.sofa.rpc.common.struct.SetDifference;
+import org.junit.Assert;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ * @author xiaojian.xj
+ * @version : CollectionDifferenceBenchMarkTest.java, v 0.1 2022年09月06日 21:45 xiaojian.xj Exp $
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(5)
+@Threads(1)
+@State(value = Scope.Benchmark)
+public class CollectionDifferenceBenchMarkTest {
+
+    private static final String URL_PATTERN = "%s:12200?rpcVer=50803&serialization=hessian2&weight=100&timeout=3000&appName=testApp&p=1&v=4.0&_SERIALIZETYPE=hessian2&_WEIGHT=100&_TIMEOUT=3000&app_name=testApp";
+
+    private static final List<ProviderInfo> EXIST = new ArrayList<>();
+
+    private static final List<ProviderInfo> UPDATE = new ArrayList<>();
+
+    private static Set<ProviderInfo> EXIST_SET;
+
+    private static Set<ProviderInfo> UPDATE_SET;
+
+    private static final String TO_BE_ADD =  String.format(URL_PATTERN, getRandomIp());
+
+    private static final String TO_BE_REMOVE =  String.format(URL_PATTERN, getRandomIp());
+
+    @Param(value = {"1000", "5000", "10000", "20000", "50000"})
+    private int LENGTH;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(CollectionDifferenceBenchMarkTest.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .result("result.json")
+                .resultFormat(ResultFormatType.JSON).build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void testListDifference() {
+        ListDifference difference = new ListDifference(EXIST, UPDATE);
+        Assert.assertEquals(difference.getOnBoth().size(), LENGTH);
+        Assert.assertEquals(difference.getOnlyOnLeft().size(), 1);
+        Assert.assertEquals(difference.getOnlyOnRight().size(), 1);
+    }
+
+    @Benchmark
+    public void testSetDifference() {
+        SetDifference difference = new SetDifference(EXIST_SET, UPDATE_SET);
+        Assert.assertEquals(difference.getOnBoth().size(), LENGTH);
+        Assert.assertEquals(difference.getOnlyOnLeft().size(), 1);
+        Assert.assertEquals(difference.getOnlyOnRight().size(), 1);
+    }
+
+    @Setup
+    public void prepareData() {
+        Set<String> existUrl = new HashSet<>();
+        for (int i = 0; i < LENGTH; i++) {
+            String url = String.format(URL_PATTERN, getRandomIp());;
+
+            while (existUrl.contains(url)) {
+                url = String.format(URL_PATTERN, getRandomIp());
+            }
+            existUrl.add(url);
+            EXIST.add(ProviderHelper.toProviderInfo(url));
+            UPDATE.add(ProviderHelper.toProviderInfo(url));
+        }
+        EXIST.add(ProviderHelper.toProviderInfo(TO_BE_REMOVE));
+        UPDATE.add(ProviderHelper.toProviderInfo(TO_BE_ADD));
+
+        EXIST_SET = new HashSet<>(EXIST);
+        UPDATE_SET = new HashSet<>(UPDATE);
+    }
+
+    @TearDown
+    public void clean() {
+        EXIST.clear();
+        UPDATE.clear();
+    }
+
+    public static String getRandomIp() {
+        Random r = new Random();
+        return r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256);
+    }
+}

--- a/core/api/src/test/java/com/alipay/sofa/rpc/bench/CollectionDifferenceBenchMarkTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/bench/CollectionDifferenceBenchMarkTest.java
@@ -64,7 +64,7 @@ public class CollectionDifferenceBenchMarkTest {
 
     private static final String TO_BE_REMOVE =  String.format(URL_PATTERN, getRandomIp());
 
-    @Param(value = {"1000", "5000", "10000", "20000", "50000"})
+    @Param(value = {"1000", "5000", "10000", "20000"})
     private int LENGTH;
 
     public static void main(String[] args) throws RunnerException {

--- a/core/common/src/main/java/com/alipay/sofa/rpc/common/struct/SetDifference.java
+++ b/core/common/src/main/java/com/alipay/sofa/rpc/common/struct/SetDifference.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2022 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.rpc.common.struct;
 

--- a/core/common/src/main/java/com/alipay/sofa/rpc/common/struct/SetDifference.java
+++ b/core/common/src/main/java/com/alipay/sofa/rpc/common/struct/SetDifference.java
@@ -1,0 +1,103 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2022 All Rights Reserved.
+ */
+package com.alipay.sofa.rpc.common.struct;
+
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ *
+ * 比较两个set的不同，列出差异部分：包括左侧独有，右侧独有，双方都有
+ * @author xiaojian.xj
+ * @version : SetDifference.java, v 0.1 2022年09月07日 15:39 xiaojian.xj Exp $
+ */
+public class SetDifference<T> {
+
+    /**
+     * The Only on left.
+     */
+    private List<T> onlyOnLeft;
+
+    /**
+     * The Only on right.
+     */
+    private List<T> onlyOnRight;
+
+    /**
+     * The On both.
+     */
+    private List<T> onBoth;
+
+    public SetDifference(Set<? extends T> left, Set<? extends T> right) {
+        if (CommonUtils.isEmpty(left) || CommonUtils.isEmpty(right)) {
+            this.onlyOnLeft = Collections.unmodifiableList(left == null ? new ArrayList<T>() : new ArrayList<T>(left));
+            this.onlyOnRight = Collections.unmodifiableList(right == null ? new ArrayList<T>() : new ArrayList<T>(right));
+            this.onBoth = Collections.unmodifiableList(new ArrayList<T>());
+            return;
+        }
+
+        List<T> onlyOnLeft = new ArrayList<>(left.size());
+        List<T> onlyOnRight = new ArrayList<T>(right.size());
+        List<T> onBoth = new ArrayList<T>(left.size());
+
+        for (T leftValue : left) {
+            if (right.contains(leftValue)) {
+                onBoth.add(leftValue);
+            } else {
+                onlyOnLeft.add(leftValue);
+            }
+        }
+
+        for (T rightValue : right) {
+            if (!left.contains(rightValue)) {
+                onlyOnRight.add(rightValue);
+            }
+        }
+
+        this.onlyOnLeft = Collections.unmodifiableList(onlyOnLeft);
+        this.onlyOnRight = Collections.unmodifiableList(onlyOnRight);
+        this.onBoth = Collections.unmodifiableList(onBoth);
+    }
+
+    /**
+     * Are equal.
+     *
+     * @return the boolean
+     */
+    public boolean areEqual() {
+        return onlyOnLeft.isEmpty() && onlyOnRight.isEmpty();
+    }
+
+    /**
+     * Gets only on left.
+     *
+     * @return the only on left
+     */
+    public List<T> getOnlyOnLeft() {
+        return onlyOnLeft;
+    }
+
+    /**
+     * Gets only on right.
+     *
+     * @return the only on right
+     */
+    public List<T> getOnlyOnRight() {
+        return onlyOnRight;
+    }
+
+    /**
+     * Gets on both.
+     *
+     * @return the on both
+     */
+    public List<T> getOnBoth() {
+        return onBoth;
+    }
+}

--- a/core/common/src/test/java/com/alipay/sofa/rpc/common/struct/SetDifferenceTest.java
+++ b/core/common/src/test/java/com/alipay/sofa/rpc/common/struct/SetDifferenceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.common.struct;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.internal.util.collections.Sets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SetDifferenceTest {
+
+    @Test
+    public void testDifference() throws Exception {
+        Set<String> s1 = Sets.newSet("111", "222", "333");
+        Set<String> s2 = Sets.newSet("111", "333", "444", "555", "666");
+
+        SetDifference difference = new SetDifference(s1, s2);
+        Assert.assertFalse(difference.areEqual());
+
+        List<String> add = difference.getOnlyOnRight();
+        List<String> removed = difference.getOnlyOnLeft();
+        List<String> same = difference.getOnBoth();
+
+        Assert.assertEquals(add.size(), 3);
+        Assert.assertEquals(removed.size(), 1);
+        Assert.assertEquals(same.size(), 2);
+
+        Assert.assertEquals(add.get(0), "444");
+        Assert.assertEquals(removed.get(0), "222");
+
+        s1 = Sets.newSet("111", "222", "333");
+        s2 = Sets.newSet("111", "333", "222");
+
+        difference = new SetDifference(s1, s2);
+        Assert.assertTrue(difference.areEqual());
+
+        add = difference.getOnlyOnRight();
+        removed = difference.getOnlyOnLeft();
+        same = difference.getOnBoth();
+
+        Assert.assertEquals(add.size(), 0);
+        Assert.assertEquals(removed.size(), 0);
+        Assert.assertEquals(same.size(), 3);
+
+        s1 = new HashSet<>();
+        s2 = Sets.newSet();
+        difference = new SetDifference(s1, s2);
+        Assert.assertTrue(difference.areEqual());
+
+        s1 = null;
+        s2 = Sets.newSet();
+        difference = new SetDifference(s1, s2);
+        Assert.assertTrue(difference.areEqual());
+
+        s1 = Collections.emptySet();
+        s2 = null;
+        difference = new SetDifference(s1, s2);
+        Assert.assertTrue(difference.areEqual());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,25 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
         <!-- Build args -->
         <revision>5.8.7</revision>
+        <jmh.version>1.33</jmh.version>
         <module.install.skip>true</module.install.skip>
         <module.deploy.skip>true</module.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>


### PR DESCRIPTION
### Motivation:

The efficiency is too low while doing list difference, when list size is 10000, it cost almost 4000ms.
![image](https://user-images.githubusercontent.com/22562143/188888059-0ad3dc23-1d34-46ac-8297-0d933840ec04.png)

### Modification:

Use set difference instead of list difference.

### Result:

SetDifference is 100 times more efficient than ListDifference, with a little more temporary memory allocation.

BenchMark result:
![image](https://user-images.githubusercontent.com/22562143/188888865-d73bc0c0-ada0-4dba-87b3-80e76aa6d4ba.png)

![image](https://user-images.githubusercontent.com/22562143/188891401-046445d9-2606-45f2-8e91-eba5dbe1643e.png)







