### PR TITLE
feat: add more parameters to nacosConfig, then you can pass usr/pwd p…

### DIFF
--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -44,6 +44,7 @@ import com.alipay.sofa.rpc.registry.utils.RegistryUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -139,6 +140,11 @@ public class NacosRegistry extends Registry {
 
         nacosConfig.put(PropertyKeyConst.SERVER_ADDR, address);
         nacosConfig.put(PropertyKeyConst.NAMESPACE, namespace);
+
+        Map<String, String> parameters = registryConfig.getParameters();
+        if (parameters != null) {
+            nacosConfig.putAll(parameters);
+        }
 
         try {
             namingService = NamingFactory.createNamingService(nacosConfig);


### PR DESCRIPTION
when nacos-registry enable auth，it will fail when register service.

### Motivation:

bypass username/password parameters to nacosConfig

please specify it in application.properties


com.alipay.sofa.rpc.registry.address=nacos://172.31.101.100:8848,172.31.101.101:8848,172.31.101.102:8848/fxiaoke?username=xxxx&password=yyyy