### PR TITLE
support json encode null and isError

### DIFF
--- a/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializer.java
+++ b/codec/codec-jackson/src/main/java/com/alipay/sofa/rpc/codec/jackson/JacksonSerializer.java
@@ -16,13 +16,6 @@
  */
 package com.alipay.sofa.rpc.codec.jackson;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
 import com.alipay.sofa.rpc.codec.AbstractSerializer;
 import com.alipay.sofa.rpc.common.RemotingConstants;
 import com.alipay.sofa.rpc.common.utils.CodecUtils;
@@ -41,6 +34,13 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * Json serializer.
@@ -101,9 +101,7 @@ public class JacksonSerializer extends AbstractSerializer {
 
     @Override
     public AbstractByteBuf encode(Object object, Map<String, String> context) throws SofaRpcException {
-        if (object == null) {
-            throw buildSerializeError("Unsupported null message!");
-        } else if (object instanceof SofaRequest) {
+        if (object instanceof SofaRequest) {
             return encodeSofaRequest((SofaRequest) object, context);
         } else if (object instanceof SofaResponse) {
             return encodeSofaResponse((SofaResponse) object, context);
@@ -312,6 +310,9 @@ public class JacksonSerializer extends AbstractSerializer {
         }
         if (isError) {
             String errorMessage = (String) decode(data, String.class, head);
+            if (errorMessage == null) {
+                errorMessage = "";
+            }
             sofaResponse.setErrorMsg(errorMessage);
         } else {
             // according interface and method name to find paramter types


### PR DESCRIPTION
Motivation:

解决一个issue问题
https://github.com/sofastack/sofa-rpc/issues/1260

Modification:
1、支持json序列化器序列化null对象。
2、支持不管异常类型中的errorMessage是否为空，都能识别为异常