### PR TITLE
code cleanup for Destroyable

### DIFF
--- a/registry/registry-consul/src/main/java/com/alipay/sofa/rpc/registry/consul/ConsulRegistry.java
+++ b/registry/registry-consul/src/main/java/com/alipay/sofa/rpc/registry/consul/ConsulRegistry.java
@@ -138,12 +138,6 @@ public class ConsulRegistry extends Registry {
         healthServiceInformers.values().forEach(HealthServiceInformer::shutdown);
     }
 
-    @Override
-    public void destroy(DestroyHook hook) {
-        hook.preDestroy();
-        destroy();
-        hook.postDestroy();
-    }
 
     @Override
     public boolean start() {

--- a/registry/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
+++ b/registry/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
@@ -292,13 +292,6 @@ public class ZookeeperRegistry extends Registry {
         consumerUrls.clear();
     }
 
-    @Override
-    public void destroy(DestroyHook hook) {
-        hook.preDestroy();
-        destroy();
-        hook.postDestroy();
-    }
-
     /**
      * 接口配置{ConsumerConfig：PathChildrenCache} <br>
      * 例如：{ConsumerConfig ： PathChildrenCache }


### PR DESCRIPTION
### Motivation:

code cleanup

base class `Registry` already implemented  method `destroy(DestroyHook hook) `


### Modification:

remove override method `destroy(DestroyHook hook) ` for ConsulRegistry & ZookeeperRegistry

### Result:


