### PR TITLE
feat: let use of javassist compatible both under java 17 and java 1.8

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -57,7 +57,7 @@
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <slf4j.version>1.7.21</slf4j.version>
         <sofa.common.tools.version>1.3.2</sofa.common.tools.version>
-        <javassist.version>3.20.0-GA</javassist.version>
+        <javassist.version>3.28.0-GA</javassist.version>
         <netty.version>4.1.44.Final</netty.version>
         <hessian.version>3.3.13</hessian.version>
         <resteasy.version>3.6.3.Final</resteasy.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <revision>5.9.2</revision>
-        <javassist.version>3.20.0-GA</javassist.version>
+        <javassist.version>3.28.0-GA</javassist.version>
         <bytebuddy.version>1.9.8</bytebuddy.version>
         <netty.version>4.1.77.Final</netty.version>
         <!-- 3rd extends libs -->

--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -128,7 +128,14 @@ public class JavassistProxy implements Proxy {
                     LOGGER.debug("javassist proxy of interface: {} \r\n{}", interfaceClass,
                         debug != null ? debug.toString() : "");
                 }
-                clazz = mCtc.toClass();
+                // Under jdk 11+, `neighbour` param is required to apply LookUp.defineClass
+                // and avoid reflect calling to Classloader.defineClass(), as calling
+                // Classloader.defineClass() from unnamed module is prohibited, which may
+                // provoke InaccessibleObjectException.
+                clazz = mPool.toClass(mCtc, interfaceClass,
+                    // use tccl as former
+                    Thread.currentThread().getContextClassLoader(),
+                    interfaceClass.getProtectionDomain());
                 PROXY_CLASS_MAP.put(interfaceClass, clazz);
             }
             Object instance = clazz.newInstance();


### PR DESCRIPTION
### Motivation:

Running com.alipay.sofa.rpc.proxy.javassist.JavassistProxyTest encounters error under jdk 17
```
        com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException: RPC-010080001: Construct proxy with [javassist] occurs error. 
	at com.alipay.sofa.rpc.proxy.javassist.JavassistProxy.getProxy(JavassistProxy.java:142)
	at com.alipay.sofa.rpc.proxy.javassist.JavassistProxyTest.getProxy(JavassistProxyTest.java:52)
        ......
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @17f052a3
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at javassist.util.proxy.SecurityActions.setAccessible(SecurityActions.java:159)
	at javassist.util.proxy.DefineClassHelper$JavaOther.defineClass(DefineClassHelper.java:213)
	at javassist.util.proxy.DefineClassHelper$Java11.defineClass(DefineClassHelper.java:52)
	at javassist.util.proxy.DefineClassHelper.toClass(DefineClassHelper.java:260)
	at javassist.ClassPool.toClass(ClassPool.java:1240)
	at javassist.ClassPool.toClass(ClassPool.java:1098)
	at javassist.ClassPool.toClass(ClassPool.java:1056)
	at javassist.CtClass.toClass(CtClass.java:1298)
	at com.alipay.sofa.rpc.proxy.javassist.JavassistProxy.getProxy(JavassistProxy.java:131)
```

For java 11+, if no `neighbour` params passed to `ClassPool.toClass`, the `javassist.util.proxy.DefineClassHelper` would make a reflection call to `java.lang.ClassLoader.DefineClass`, which is, however, inaccessbile from unnamed module under java 17.


### Modification:

Use `javassist.ClassPool#toClass(javassist.CtClass, java.lang.Class<?>, java.lang.ClassLoader, java.security.ProtectionDomain)` instead of `javassist.CtClass#toClass()`.

### Result:

com.alipay.sofa.rpc.proxy.javassist.JavassistProxyTest works both under java 17 and java 1.8.
