### PR TITLE
代码扫描fix

### DIFF
--- a/.github/workflows/cloud_code_scan.yml
+++ b/.github/workflows/cloud_code_scan.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: codeScan
-        uses: layotto/alipay-cloud-devops-codescan@0.1.20230721
+        uses: layotto/alipay-cloud-devops-codescan@0.1.20230724
         with:
           parent_uid: ${{ secrets.ALI_PID }}
           private_key: ${{ secrets.ALI_PK }}


### PR DESCRIPTION
1,现在会显示所有high和urgent级别的错误,只有high以下级别警告时视为通过
2,修正了之前只有high级别的警告时读取title报错的问题

