### PR TITLE
1,修复gson版本导致的漏洞

### DIFF
--- a/config/config-apollo/pom.xml
+++ b/config/config-apollo/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.ctrip.framework.apollo</groupId>
             <artifactId>apollo-client</artifactId>
-            <version>1.4.0</version>
+            <version>2.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
修复由小程序云代码扫描报出的漏洞:
危害等级：高危
漏洞类型：反序列化漏洞
漏洞子类型：MPS-2022-12287_com.google.code.gson_gson
漏洞编号:
MPS-2022-12287
CVE-2022-25647
漏洞状态： 漏洞提交
首次发现时间：2023-07-21 13:39:52
最近发现时间：2023-08-08 16:02:39
漏洞基因编码：b953014247a1a4716f6d56e1f7e51ad3
漏洞源文件：http://github.com/sofastack/sofa-rpc/blob/master/config/config-apollo/pom.xml
详细内容:
{
间接依赖的组件是:
		<groupId>com.google.code.gson</groupId>
		<artifactId>[H[gson]H]</artifactId>
		
间接依赖链路如下:
com.ctrip.framework.apollo:apollo-client:1.4.0->com.google.code.gson:gson:2.8.0

对应的修复版本为:
		<version>2.8.9</version>
}
