### PR TITLE
bugfix: Compatible with Protobuf empty object.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -539,6 +539,12 @@
                 <version>4.3.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>4.3.0</version>
+                <scope>test</scope>
+            </dependency>
             <!-- h2 SSL libs -->
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>

--- a/remoting/remoting-bolt/pom.xml
+++ b/remoting/remoting-bolt/pom.xml
@@ -37,6 +37,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-rpc-test-common</artifactId>
             <version>${project.parent.version}</version>
@@ -50,6 +56,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientInvoker.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientInvoker.java
@@ -137,14 +137,12 @@ public class TripleClientInvoker implements TripleInvoker {
                 buildCustomCallOptions(sofaRequest, timeout), request);
 
             SofaResponse sofaResponse = new SofaResponse();
-            byte[] responseDate = response.getData().toByteArray();
+            byte[] responseData = response.getData().toByteArray();
             Class returnType = sofaRequest.getMethod().getReturnType();
             if (returnType != void.class) {
-                if (responseDate != null && responseDate.length > 0) {
-                    Serializer responseSerializer = SerializerFactory.getSerializer(response.getSerializeType());
-                    Object appResponse = responseSerializer.decode(new ByteArrayWrapperByteBuf(responseDate), returnType, null);
-                    sofaResponse.setAppResponse(appResponse);
-                }
+                Serializer responseSerializer = SerializerFactory.getSerializer(response.getSerializeType());
+                Object appResponse = responseSerializer.decode(new ByteArrayWrapperByteBuf(responseData), returnType, null);
+                sofaResponse.setAppResponse(appResponse);
             }
 
             return sofaResponse;
@@ -250,13 +248,11 @@ public class TripleClientInvoker implements TripleInvoker {
             Object appResponse = o;
             if (needDecode) {
                 Response response = (Response) o;
-                byte[] responseDate = response.getData().toByteArray();
+                byte[] responseData = response.getData().toByteArray();
                 Class returnType = sofaRequest.getMethod().getReturnType();
                 if (returnType != void.class) {
-                    if (responseDate != null && responseDate.length > 0) {
-                        Serializer responseSerializer = SerializerFactory.getSerializer(response.getSerializeType());
-                        appResponse = responseSerializer.decode(new ByteArrayWrapperByteBuf(responseDate), returnType, null);
-                    }
+                    Serializer responseSerializer = SerializerFactory.getSerializer(response.getSerializeType());
+                    appResponse = responseSerializer.decode(new ByteArrayWrapperByteBuf(responseData), returnType, null);
                 }
             }
 


### PR DESCRIPTION
### Motivation:
When sending or returning a Protobuf empty object with a content length of 0,just like `PagePB.Response.getDefaultInstance()`, the client or server will report an error. This modification will be compatible with this situation.

```
03:03:00.363 [SOFA-SEV-BOLT-BIZ-12200-3-T2] ERROR c.a.s.r.c.bolt.SofaRpcSerialization - traceId=null, rpcId=null, Request deserializeContent exception, msg=Content of request is null
com.alipay.remoting.exception.DeserializationException: Content of request is null
	at com.alipay.sofa.rpc.codec.bolt.SofaRpcSerialization.deserializeContent(SofaRpcSerialization.java:273)
	at com.alipay.remoting.rpc.protocol.RpcRequestCommand.deserializeContent(RpcRequestCommand.java:148)
	at com.alipay.remoting.rpc.RpcCommand.deserialize(RpcCommand.java:117)
	at com.alipay.remoting.rpc.RpcCommand.deserialize(RpcCommand.java:138)
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.deserializeRequestCommand(RpcRequestProcessor.java:286)
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.doProcess(RpcRequestProcessor.java:143)
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor$ProcessTask.run(RpcRequestProcessor.java:393)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1623)
```

```
Exception in thread "main" com.alipay.sofa.rpc.core.exception.SofaRpcException: Failed to call org.apache.dubbo.benchmark.bean.UserServiceDubbo$IUserService.createUser on remote server bolt://127.0.0.1:12200, return null
	at com.alipay.sofa.rpc.client.FailoverCluster.doInvoke(FailoverCluster.java:81)
	at com.alipay.sofa.rpc.client.AbstractCluster.invoke(AbstractCluster.java:298)
	at com.alipay.sofa.rpc.client.ClientProxyInvoker.invoke(ClientProxyInvoker.java:83)
```

