### PR TITLE
enhance: reuse thread pool for scheduled service

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AllConnectConnectionHolder.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AllConnectConnectionHolder.java
@@ -849,13 +849,12 @@ public class AllConnectConnectionHolder extends ConnectionHolder {
      * 启动重连+心跳线程
      */
     protected void startReconnectThread() {
-        final String interfaceId = consumerConfig.getInterfaceId();
         // 启动线程池
         // 默认每隔10秒重连
         int reconnect = consumerConfig.getReconnectPeriod();
         if (reconnect > 0) {
             reconnect = Math.max(reconnect, 2000); // 最小2000
-            reconThread = new ScheduledService("CLI-RC-" + interfaceId, ScheduledService.MODE_FIXEDDELAY, new
+            reconThread = new ScheduledService("CLI-RC-CONSUMER", ScheduledService.MODE_FIXEDDELAY, new
                 Runnable() {
                     @Override
                     public void run() {
@@ -863,7 +862,7 @@ public class AllConnectConnectionHolder extends ConnectionHolder {
                             doReconnect();
                         } catch (Throwable e) {
                             LOGGER.warnWithApp(consumerConfig.getAppName(),
-                                "Exception when retry connect to provider", e);
+                                "Exception when retry connect to provider " + consumerConfig.getInterfaceId(), e);
                         }
                     }
                 }, reconnect, reconnect, TimeUnit.MILLISECONDS).start();

--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/threadpool/extension/ReuseScheduledThreadPoolFactory.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/threadpool/extension/ReuseScheduledThreadPoolFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.common.threadpool.extension;
+
+import com.alipay.sofa.rpc.common.struct.NamedThreadFactory;
+import com.alipay.sofa.rpc.common.threadpool.SofaExecutorFactory;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.ext.Extension;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+/**
+ * same ScheduledThreadPoolExecutor will be used for same name prefix
+ * wont create new executor if executor already exist for namePrefix
+ *
+ * @author junyuan
+ * @version ReuseScheduledThreadPoolFactory.java, v 0.1 2024-01-15 19:44 junyuan Exp $
+ */
+@Extension("reuse-scheduled")
+public class ReuseScheduledThreadPoolFactory implements SofaExecutorFactory {
+
+    Map<String, Executor> uniqueMap = new ConcurrentHashMap<>();
+
+    @Override
+    public Executor createExecutor(String namePrefix, ServerConfig serverConfig) {
+        return uniqueMap.computeIfAbsent(namePrefix, key -> new ScheduledThreadPoolExecutor(1, new NamedThreadFactory(namePrefix, true)));
+    }
+}

--- a/core/api/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.common.threadpool.SofaExecutorFactory
+++ b/core/api/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.common.threadpool.SofaExecutorFactory
@@ -1,2 +1,3 @@
 cached=com.alipay.sofa.rpc.common.threadpool.extension.CachedThreadPoolFactory
 virtual=com.alipay.sofa.rpc.common.threadpool.extension.VirtualThreadPoolFactory
+reuse-scheduled=com.alipay.sofa.rpc.common.threadpool.extension.ReuseScheduledThreadPoolFactory

--- a/core/api/src/test/java/com/alipay/sofa/rpc/common/threadpool/extension/ReuseScheduledThreadPoolFactoryTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/common/threadpool/extension/ReuseScheduledThreadPoolFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.common.threadpool.extension;
+
+import com.alipay.sofa.rpc.common.threadpool.SofaExecutorFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Executor;
+
+/**
+ *
+ * @author junyuan
+ * @version ReuseScheduledThreadPoolFactoryTest.java, v 0.1 2024-01-15 20:18 junyuan Exp $
+ */
+public class ReuseScheduledThreadPoolFactoryTest {
+
+    @Test
+    public void testReuse() {
+        String testPrefix = "prefix-for-factory-test";
+
+        SofaExecutorFactory factory = new ReuseScheduledThreadPoolFactory();
+
+        Executor executor1 = factory.createExecutor(testPrefix, null);
+        Executor executor2 = factory.createExecutor(testPrefix, null);
+
+        Assert.assertEquals(executor1, executor2);
+
+        Executor executor3 = factory.createExecutor("new-prefix-for-factory-test", null);
+
+        Assert.assertNotEquals(executor1, executor3);
+    }
+}


### PR DESCRIPTION
### Motivation:

It might be exhausted when create new executor pool for some scheduled cases such as reconnection, where each consumer may has its own scheduled executor pool and its own thread. Amount of threads may grow to O(m) aligns with amount of consumers.

### Modification:

add a reused schedule pool that may provide same pool with same unique key

### Result:

