### PR TITLE
fix #1380, create NacosRegistryProviderObserver  when init method is executed

### DIFF
--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alipay.sofa.rpc.client.ProviderGroup;
 import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.annotation.VisibleForTesting;
 import com.alipay.sofa.rpc.common.utils.CommonUtils;
 import com.alipay.sofa.rpc.common.utils.StringUtils;
 import com.alipay.sofa.rpc.config.ConsumerConfig;
@@ -360,7 +361,7 @@ public class NacosRegistry extends Registry {
      *
      * @return
      */
-    @Deprecated
+    @VisibleForTesting
     public NacosRegistryProviderObserver getProviderObserver() {
         return providerObserver;
     }

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -149,21 +149,17 @@ public class NacosRegistry extends Registry {
             nacosConfig.putAll(parameters);
         }
 
+        lock.lock();
         try {
             if (providerObserver == null) {
-                lock.lock();
-                try {
-                    if (providerObserver == null) {
-                        providerObserver = new NacosRegistryProviderObserver();
-                    }
-                } finally {
-                    lock.unlock();
-                }
+                providerObserver = new NacosRegistryProviderObserver();
             }
 
             namingService = NamingFactory.createNamingService(nacosConfig);
         } catch (NacosException e) {
             throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_INIT_NACOS_NAMING_SERVICE, address), e);
+        }finally {
+            lock.unlock();
         }
     }
 

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -91,7 +91,7 @@ public class NacosRegistry extends Registry {
 
     private NamingService                                 namingService;
 
-    private static volatile NacosRegistryProviderObserver                 providerObserver;
+    private static volatile NacosRegistryProviderObserver providerObserver;
 
     private List<String>                                  defaultCluster;
 

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -380,4 +380,14 @@ public class NacosRegistry extends Registry {
     public Properties getNacosConfig() {
         return nacosConfig;
     }
+
+    /**
+     * UT only
+     *
+     * @return
+     */
+    @Deprecated
+    public NacosRegistryProviderObserver getProviderObserver() {
+        return providerObserver;
+    }
 }

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -158,7 +158,7 @@ public class NacosRegistry extends Registry {
             namingService = NamingFactory.createNamingService(nacosConfig);
         } catch (NacosException e) {
             throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_INIT_NACOS_NAMING_SERVICE, address), e);
-        }finally {
+        } finally {
             lock.unlock();
         }
     }

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -68,12 +68,12 @@ import static com.alipay.sofa.rpc.common.utils.StringUtils.CONTEXT_SEP;
  *        |--com.alipay.sofa.rpc.example.EchoService (next serviceName):grpc (protocol)
  *        |......
  * </pre>
- *
- *  Remark:
- *  Here we register service name with not only serviceName, but also with 'uniqueId' and 'protocol',
- *  because in Nacos, all service instances(with same service name) are only identified by ip and port,
- *  if there are two service with same service name but different uniqueId, there will be only one instance remained in instance list,
- *  and the consumer can't find the other instance from Nacos
+ * <p>
+ * Remark:
+ * Here we register service name with not only serviceName, but also with 'uniqueId' and 'protocol',
+ * because in Nacos, all service instances(with same service name) are only identified by ip and port,
+ * if there are two service with same service name but different uniqueId, there will be only one instance remained in instance list,
+ * and the consumer can't find the other instance from Nacos
  * </p>
  *
  * @author <a href=mailto:jervyshi@gmail.com>JervyShi</a>
@@ -290,7 +290,7 @@ public class NacosRegistry extends Registry {
                 try {
                     lock.lock();
                     providerObserver.addProviderListener(config, providerInfoListener);
-                }finally {
+                } finally {
                     lock.unlock();
                 }
 
@@ -306,7 +306,7 @@ public class NacosRegistry extends Registry {
                         try {
                             lock.lock();
                             providerObserver.updateProviders(config, instances);
-                        }finally {
+                        } finally {
                             lock.unlock();
                         }
                     }

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -145,11 +145,11 @@ public class NacosRegistry extends Registry {
             nacosConfig.putAll(parameters);
         }
 
-        try {
-            if (providerObserver == null) {
-                providerObserver = new NacosRegistryProviderObserver();
-            }
+        if (providerObserver == null) {
+            providerObserver = new NacosRegistryProviderObserver();
+        }
 
+        try {
             namingService = NamingFactory.createNamingService(nacosConfig);
         } catch (NacosException e) {
             throw new SofaRpcRuntimeException(LogCodes.getLog(LogCodes.ERROR_INIT_NACOS_NAMING_SERVICE, address), e);

--- a/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
+++ b/registry/registry-nacos/src/main/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistry.java
@@ -20,7 +20,6 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingFactory;
 import com.alibaba.nacos.api.naming.NamingService;
-import com.alibaba.nacos.api.naming.listener.Event;
 import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;

--- a/registry/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryTest.java
+++ b/registry/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryTest.java
@@ -82,9 +82,9 @@ public class NacosRegistryTest extends BaseNacosTest {
     }
 
     @Test
-    public void testMulitInit() throws InterruptedException {
+    public void testMuiltInit() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(10);
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(10);
         Set<NacosRegistryProviderObserver> sets = new ConcurrentHashSet<>();
 
         for (int i = 0; i < 10; i++) {

--- a/registry/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryTest.java
+++ b/registry/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryTest.java
@@ -18,6 +18,7 @@ package com.alipay.sofa.rpc.registry.nacos;
 
 import com.alipay.sofa.rpc.client.ProviderGroup;
 import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.struct.ConcurrentHashSet;
 import com.alipay.sofa.rpc.config.ApplicationConfig;
 import com.alipay.sofa.rpc.config.ConsumerConfig;
 import com.alipay.sofa.rpc.config.ProviderConfig;
@@ -36,9 +37,12 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -66,8 +70,6 @@ public class NacosRegistryTest extends BaseNacosTest {
             .setRegister(true);
 
         registry = (NacosRegistry) RegistryFactory.getRegistry(registryConfig);
-        registry.init();
-        Assert.assertTrue(registry.start());
     }
 
     /**
@@ -77,7 +79,30 @@ public class NacosRegistryTest extends BaseNacosTest {
     public void tearDown() {
         registry.destroy();
         registry = null;
-        serverConfig.destroy();
+    }
+
+    @Test
+    public void testMulitInit() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        final CountDownLatch latch = new CountDownLatch(1);
+        Set<NacosRegistryProviderObserver> sets = new ConcurrentHashSet<>();
+
+        for (int i = 0; i < 10; i++) {
+            executorService.submit(() -> {
+                try {
+                    registry.init();
+                    NacosRegistryProviderObserver providerObserver = registry.getProviderObserver();
+                    sets.add(providerObserver);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        Assert.assertEquals(1, sets.size());
     }
 
     /**
@@ -87,6 +112,8 @@ public class NacosRegistryTest extends BaseNacosTest {
      */
     @Test
     public void testProviderObserver() throws Exception {
+        registry.init();
+        Assert.assertTrue(registry.start());
         int timeoutPerSub = 2000;
 
         //wait nacos startup ok
@@ -227,6 +254,7 @@ public class NacosRegistryTest extends BaseNacosTest {
         List<ConsumerConfig> consumerConfigList = new ArrayList<>();
         consumerConfigList.add(consumer2);
         registry.batchUnSubscribe(consumerConfigList);
+        serverConfig.destroy();
     }
 
     /**
@@ -236,6 +264,9 @@ public class NacosRegistryTest extends BaseNacosTest {
      */
     @Test
     public void testVirtualHostAndVirtualPort() throws Exception {
+        registry.init();
+        Assert.assertTrue(registry.start());
+
         //wait nacos startup ok
         TimeUnit.SECONDS.sleep(10);
         // 模拟的场景 client -> proxy:127.7.7.7:8888 -> netty:0.0.0.0:12200
@@ -297,6 +328,7 @@ public class NacosRegistryTest extends BaseNacosTest {
             virtualHost + ":" + virtualPort);
         Assert.assertEquals("The provider's host should be virtualHost", virtualHost, pri.getHost());
         Assert.assertEquals("The provider's port should be virtualPort", virtualPort, pri.getPort());
+        serverConfig.destroy();
     }
 
     private static class MockProviderInfoListener implements ProviderInfoListener {


### PR DESCRIPTION
fix #1380 修改之前的代码创建NacosRegistryProviderObserver是在subscribe里的，修改之后创建NacosRegistryProviderObserver是在init方法里的，init是有同步锁的。