### PR TITLE
Extension kubernetes registry

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -246,6 +246,11 @@
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-registry-kubernetes</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-rpc-remoting-bolt</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -545,6 +550,7 @@
                                     <include>com.alipay.sofa:sofa-rpc-registry-multicast</include>
                                     <include>com.alipay.sofa:sofa-rpc-registry-sofa</include>
                                     <include>com.alipay.sofa:sofa-rpc-registry-polaris</include>
+                                    <include>com.alipay.sofa:sofa-rpc-registry-kubernetes</include>
                                     <include>com.alipay.sofa:sofa-rpc-remoting-bolt</include>
                                     <include>com.alipay.sofa:sofa-rpc-remoting-http</include>
                                     <include>com.alipay.sofa:sofa-rpc-remoting-resteasy</include>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -60,6 +60,8 @@
         <!-- Build args -->
         <module.install.skip>true</module.install.skip>
         <module.deploy.skip>true</module.deploy.skip>
+        <!-- Fabric8 for Kubernetes -->
+        <fabric8_kubernetes_version>6.9.2</fabric8_kubernetes_version>
     </properties>
 
     <dependencyManagement>
@@ -512,6 +514,19 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-stub</artifactId>
                 <version>${grpc.version}</version>
+            </dependency>
+
+            <!-- Fabric8 for Kubernetes -->
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client</artifactId>
+                <version>${fabric8_kubernetes_version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <scope>test</scope>
+                <version>${fabric8_kubernetes_version}</version>
             </dependency>
 
             <!-- Test libs -->

--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/RegistryConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/RegistryConfig.java
@@ -398,6 +398,36 @@ public class RegistryConfig extends AbstractIdConfig implements Serializable {
         return parameters == null ? null : parameters.get(key);
     }
 
+    /**
+     * Gets parameter or default.
+     *
+     * @param key the key
+     * @return the value
+     */
+    public String getParameter(String key, String defaultValue) {
+        return getParameter(key) == null ? defaultValue : getParameter(key);
+    }
+
+    /**
+     * Gets parameter or default.
+     *
+     * @param key the key
+     * @return the value
+     */
+    public int getParameter(String key, int defaultValue) {
+        return getParameter(key) == null ? defaultValue : Integer.parseInt(parameters.get(key));
+    }
+
+    /**
+     * Gets parameter or default.
+     *
+     * @param key the key
+     * @return the value
+     */
+    public boolean getParameter(String key, boolean defaultValue) {
+        return getParameter(key) == null ? defaultValue : Boolean.parseBoolean(parameters.get(key));
+    }
+
     @Override
     public String toString() {
         return "RegistryConfig{" +

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -22,6 +22,7 @@
         <module>registry-multicast</module>
         <module>registry-sofa</module>
         <module>registry-polaris</module>
+        <module>registry-kubernetes</module>
     </modules>
 
     <dependencyManagement>

--- a/registry/registry-kubernetes/pom.xml
+++ b/registry/registry-kubernetes/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.alipay.sofa</groupId>
+        <artifactId>sofa-rpc-registry</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>sofa-rpc-registry-kubernetes</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-codec-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistry.java
+++ b/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistry.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+import com.alipay.sofa.rpc.client.ProviderGroup;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.annotation.VisibleForTesting;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.RegistryConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.ext.Extension;
+import com.alipay.sofa.rpc.listener.ProviderInfoListener;
+import com.alipay.sofa.rpc.log.LogCodes;
+import com.alipay.sofa.rpc.log.Logger;
+import com.alipay.sofa.rpc.log.LoggerFactory;
+import com.alipay.sofa.rpc.registry.Registry;
+import com.alipay.sofa.rpc.registry.kubernetes.utils.KubernetesClientUtils;
+import com.alipay.sofa.rpc.registry.kubernetes.utils.KubernetesConfigUtils;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Extension("kubernetes")
+public class KubernetesRegistry extends Registry {
+
+    /**
+     * slf4j Logger for this class
+     */
+    private final static Logger LOGGER = LoggerFactory.getLogger(KubernetesRegistry.class);
+
+    private KubernetesClient kubernetesClient;
+
+    private String currentHostname;
+
+    private String namespace;
+
+    private KubernetesRegistryProviderWatcher kubernetesRegistryProviderWatcher;
+
+    private final ConcurrentMap<ConsumerConfig, SharedIndexInformer<Pod>> consumerListeners = new ConcurrentHashMap<>(64);
+
+    /**
+     * Instantiates a new kubernetes registry.
+     *
+     * @param registryConfig
+     */
+    public KubernetesRegistry(RegistryConfig registryConfig) {
+        super(registryConfig);
+    }
+
+    @Override
+    public synchronized void init() {
+        // init kubernetes config
+        Config config = KubernetesConfigUtils.buildKubernetesConfig(registryConfig);
+        // init kubernetes client
+        if (kubernetesClient == null) {
+            this.kubernetesClient = KubernetesClientUtils.buildKubernetesClient(config);
+        }
+        // init Watcher
+        if (kubernetesRegistryProviderWatcher == null) {
+            kubernetesRegistryProviderWatcher = new KubernetesRegistryProviderWatcher();
+        }
+        this.currentHostname = System.getenv("HOSTNAME");
+        this.namespace = config.getNamespace();
+    }
+
+    @Override
+    public boolean start() {
+        return true;
+    }
+
+    @Override
+    public void register(ProviderConfig config) {
+        String appName = config.getAppName();
+        if (!registryConfig.isRegister()) {
+            if (LOGGER.isInfoEnabled(appName)) {
+                LOGGER.infoWithApp(appName, LogCodes.getLog(LogCodes.INFO_REGISTRY_IGNORE));
+            }
+            return;
+        }
+
+        if (config.isRegister()) {
+            PodResource podResource = kubernetesClient.pods()
+                    .inNamespace(namespace)
+                    .withName(currentHostname);
+
+            List<ServerConfig> serverConfigs = config.getServer();
+
+            if (CommonUtils.isNotEmpty(serverConfigs)) {
+                for (ServerConfig serverConfig : serverConfigs) {
+                    String dataId = KubernetesRegistryHelper.buildDataId(config, serverConfig.getProtocol());
+                    // 对外提供服务的URL
+                    String url = KubernetesRegistryHelper.convertToUrl(podResource.get(), serverConfig, config);
+
+                    podResource.edit(pod -> new PodBuilder(pod).editOrNewMetadata()
+                            // 将ProviderConfig存在Annotations上
+                            .addToAnnotations(dataId, url)
+                            // 为了过滤pod、其实value是用不到的
+                            .addToLabels(dataId, "")
+                            .endMetadata().build());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void unRegister(ProviderConfig config) {
+        String appName = config.getAppName();
+        if (!registryConfig.isRegister()) {
+            if (LOGGER.isInfoEnabled(appName)) {
+                LOGGER.infoWithApp(appName, LogCodes.getLog(LogCodes.INFO_REGISTRY_IGNORE));
+            }
+            return;
+        }
+
+        if (config.isRegister()) {
+            PodResource podResource = kubernetesClient.pods()
+                    .inNamespace(namespace)
+                    .withName(currentHostname);
+
+            List<ServerConfig> serverConfigs = config.getServer();
+            if (CommonUtils.isNotEmpty(serverConfigs)) {
+                for (ServerConfig serverConfig : serverConfigs) {
+                    String dataId = KubernetesRegistryHelper.buildDataId(config, serverConfig.getProtocol());
+
+                    podResource.edit(pod -> new PodBuilder(pod).editOrNewMetadata()
+                            .removeFromAnnotations(dataId)
+                            .removeFromLabels(dataId)
+                            .endMetadata()
+                            .build());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void batchUnRegister(List<ProviderConfig> configs) {
+        // one by one
+        for (ProviderConfig config : configs) {
+            try {
+                this.unRegister(config);
+            } catch (Exception e) {
+                LOGGER.errorWithApp(config.getAppName(), "Batch unregister error", e);
+            }
+        }
+    }
+
+    @Override
+    public List<ProviderGroup> subscribe(ConsumerConfig config) {
+        String appName = config.getAppName();
+        if (!registryConfig.isSubscribe()) {
+            // registry ignored
+            if (LOGGER.isInfoEnabled(appName)) {
+                LOGGER.infoWithApp(appName, LogCodes.getLog(LogCodes.INFO_REGISTRY_IGNORE));
+            }
+            return null;
+        }
+
+        if (config.isSubscribe()) {
+
+            ProviderInfoListener providerInfoListener = config.getProviderInfoListener();
+            kubernetesRegistryProviderWatcher.addProviderListener(config, providerInfoListener);
+
+            String dataId = KubernetesRegistryHelper.buildDataId(config, config.getProtocol());
+            FilterWatchListDeletable<Pod, PodList, PodResource> podPodListPodResourceFilterWatchListDeletable =
+                    kubernetesClient.pods()
+                            .inNamespace(namespace)
+                            .withLabel(dataId);
+
+            SharedIndexInformer<Pod> inform = podPodListPodResourceFilterWatchListDeletable.inform(new ResourceEventHandler<Pod>() {
+                @Override
+                public void onAdd(Pod pod) {
+                    kubernetesRegistryProviderWatcher.updateProviders(config, getPods());
+                }
+
+                @Override
+                public void onUpdate(Pod pod, Pod t1) {
+                    kubernetesRegistryProviderWatcher.updateProviders(config, getPods());
+                }
+
+                @Override
+                public void onDelete(Pod pod, boolean b) {
+                    kubernetesRegistryProviderWatcher.updateProviders(config, getPods());
+                }
+            });
+
+            consumerListeners.put(config, inform);
+
+            inform.start();
+
+            List<Pod> pods = podPodListPodResourceFilterWatchListDeletable.list().getItems();
+            List<ProviderInfo> providerInfos = KubernetesRegistryHelper.convertPodsToProviders(pods, config);
+            return Collections.singletonList(new ProviderGroup().addAll(providerInfos));
+        }
+
+        return null;
+    }
+
+    @Override
+    public void unSubscribe(ConsumerConfig config) {
+        if (config.isSubscribe()) {
+            SharedIndexInformer<Pod> informer = consumerListeners.remove(config);
+            if (null != informer) {
+                informer.stop();
+            }
+        }
+
+        kubernetesRegistryProviderWatcher.removeProviderListener(config);
+    }
+
+    @Override
+    public void batchUnSubscribe(List<ConsumerConfig> configs) {
+        // one by one
+        for (ConsumerConfig config : configs) {
+            try {
+                this.unSubscribe(config);
+            } catch (Exception e) {
+                LOGGER.errorWithApp(config.getAppName(), "Batch unSubscribe error", e);
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // unRegister consumer
+        consumerListeners.forEach((k, v) -> unSubscribe(k));
+
+        // close kubernetes client
+        kubernetesClient.close();
+    }
+
+    private List<Pod> getPods() {
+        return kubernetesClient.pods()
+                .inNamespace(namespace)
+                .list()
+                .getItems();
+    }
+
+    /**
+     * UT used only
+     */
+    @VisibleForTesting
+    public void setCurrentHostname(String currentHostname) {
+        this.currentHostname = currentHostname;
+    }
+
+    /**
+     * UT used only
+     */
+    @VisibleForTesting
+    public ConcurrentMap<ConsumerConfig, SharedIndexInformer<Pod>> getConsumerListeners() {
+        return consumerListeners;
+    }
+}

--- a/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistryHelper.java
+++ b/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistryHelper.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+import com.alipay.sofa.rpc.client.ProviderHelper;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.AbstractInterfaceConfig;
+import com.alipay.sofa.rpc.config.ConfigUniqueNameGenerator;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.log.Logger;
+import com.alipay.sofa.rpc.log.LoggerFactory;
+import com.alipay.sofa.rpc.registry.utils.RegistryUtils;
+import io.fabric8.kubernetes.api.model.Pod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class KubernetesRegistryHelper extends RegistryUtils {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(KubernetesRegistryHelper.class);
+
+    public static List<ProviderInfo> convertPodsToProviders(List<Pod> pods, ConsumerConfig config) {
+        List<ProviderInfo> providerInfos = new ArrayList<>();
+        if (CommonUtils.isEmpty(pods) || null == config) {
+            return providerInfos;
+        }
+
+        for (Pod pod : pods) {
+            ProviderInfo providerInfo = getProviderInfo(pod, config);
+            if (null == providerInfo) {
+                continue;
+            }
+            providerInfos.add(providerInfo);
+        }
+
+        return providerInfos;
+    }
+
+    public static String convertToUrl(Pod pod, ServerConfig serverConfig, ProviderConfig providerConfig) {
+        String uri = "";
+        String protocol = serverConfig.getProtocol();
+        if (StringUtils.isNotEmpty(protocol)) {
+            uri = protocol + "://";
+        }
+        uri += pod.getStatus().getPodIP() + ":" + serverConfig.getPort();
+
+        Map<String, String> metaData = RegistryUtils.convertProviderToMap(providerConfig, serverConfig);
+
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : metaData.entrySet()) {
+            sb.append("&").append(entry.getKey()).append("=").append(entry.getValue());
+        }
+        if (sb.length() > 0) {
+            uri += sb.replace(0, 1, "?").toString();
+        }
+        return uri;
+    }
+
+    private static ProviderInfo getProviderInfo(Pod pod, ConsumerConfig config) {
+        try {
+            String dataId = buildDataId(config, config.getProtocol());
+            String providerUrlString = pod.getMetadata().getAnnotations().get(dataId);
+
+            if (StringUtils.isBlank(providerUrlString)) {
+                return null;
+            }
+            return ProviderHelper.toProviderInfo(providerUrlString);
+        } catch (Exception e) {
+            LOGGER.info("get provider config error with pod");
+            return null;
+        }
+    }
+
+    public static String buildDataId(AbstractInterfaceConfig config, String protocol) {
+        if (RpcConstants.PROTOCOL_TYPE_BOLT.equals(protocol) || RpcConstants.PROTOCOL_TYPE_TR.equals(protocol)) {
+            return ConfigUniqueNameGenerator.getUniqueName(config) + "@DEFAULT";
+        } else {
+            return ConfigUniqueNameGenerator.getUniqueName(config) + "@" + protocol;
+        }
+    }
+}

--- a/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistryProviderWatcher.java
+++ b/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistryProviderWatcher.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+import com.alipay.sofa.rpc.client.ProviderGroup;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.listener.ProviderInfoListener;
+import com.alipay.sofa.rpc.registry.utils.RegistryUtils;
+import io.fabric8.kubernetes.api.model.Pod;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class KubernetesRegistryProviderWatcher {
+
+    /**
+     * The Provider add listener map.
+     */
+    private final ConcurrentMap<ConsumerConfig, List<ProviderInfoListener>> providerListenerMap = new ConcurrentHashMap<>();
+
+    /**
+     * Add provider listener.
+     *
+     * @param consumerConfig the consumer config
+     * @param listener       the listener
+     */
+    public void addProviderListener(ConsumerConfig consumerConfig, ProviderInfoListener listener) {
+        if (listener != null) {
+            RegistryUtils.initOrAddList(providerListenerMap, consumerConfig, listener);
+        }
+    }
+
+    /**
+     * Remove provider listener.
+     *
+     * @param consumerConfig the consumer config
+     */
+    public void removeProviderListener(ConsumerConfig consumerConfig) {
+        providerListenerMap.remove(consumerConfig);
+    }
+
+    /**
+     * Update providers.
+     *
+     * @param config  the config
+     * @param podList the pod list
+     */
+    public void updateProviders(ConsumerConfig config, List<Pod> podList) {
+        List<ProviderInfoListener> providerInfoListeners = providerListenerMap.get(config);
+        if (CommonUtils.isNotEmpty(providerInfoListeners)) {
+            List<ProviderInfo> providerInfos = KubernetesRegistryHelper.convertPodsToProviders(podList, config);
+
+            for (ProviderInfoListener providerInfoListener : providerInfoListeners) {
+                providerInfoListener.updateAllProviders(Collections.singletonList(new ProviderGroup().addAll(providerInfos)));
+            }
+        }
+    }
+
+}

--- a/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/constant/KubernetesClientConstants.java
+++ b/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/constant/KubernetesClientConstants.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes.constant;
+
+public class KubernetesClientConstants {
+
+    public static final String DEFAULT_MASTER_URL       = "https://kubernetes.default.svc";
+
+    public static final String TRUST_CERTS              = "trustCerts";
+
+    public static final String USE_HTTPS                = "useHttps";
+
+    public static final String HTTP2_DISABLE            = "http2Disable";
+
+    public static final String NAMESPACE                = "namespace";
+
+    public static final String API_VERSION              = "apiVersion";
+
+    public static final String CA_CERT_FILE             = "caCertFile";
+
+    public static final String CA_CERT_DATA             = "caCertData";
+
+    public static final String CLIENT_CERT_FILE         = "clientCertFile";
+
+    public static final String CLIENT_CERT_DATA         = "clientCertData";
+
+    public static final String CLIENT_KEY_FILE          = "clientKeyFile";
+
+    public static final String CLIENT_KEY_DATA          = "clientKeyData";
+
+    public static final String CLIENT_KEY_ALGO          = "clientKeyAlgo";
+
+    public static final String CLIENT_KEY_PASSPHRASE    = "clientKeyPassphrase";
+
+    public static final String OAUTH_TOKEN              = "oauthToken";
+
+    public static final String USERNAME                 = "username";
+
+    public static final String PASSWORD                 = "password";
+
+    public static final String WATCH_RECONNECT_INTERVAL = "watchReconnectInterval";
+
+    public static final String WATCH_RECONNECT_LIMIT    = "watchReconnectLimit";
+
+    public static final String CONNECTION_TIMEOUT       = "connectionTimeout";
+
+    public static final String REQUEST_TIMEOUT          = "requestTimeout";
+
+    public static final String LOGGING_INTERVAL         = "loggingInterval";
+
+    public static final String HTTP_PROXY               = "httpProxy";
+
+    public static final String HTTPS_PROXY              = "httpsProxy";
+
+    public static final String PROXY_USERNAME           = "proxyUsername";
+
+    public static final String PROXY_PASSWORD           = "proxyPassword";
+
+}

--- a/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/utils/KubernetesClientUtils.java
+++ b/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/utils/KubernetesClientUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes.utils;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+
+public class KubernetesClientUtils {
+
+    public static KubernetesClient buildKubernetesClient(Config config) {
+        return new KubernetesClientBuilder().withConfig(config).build();
+    }
+}

--- a/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/utils/KubernetesConfigUtils.java
+++ b/registry/registry-kubernetes/src/main/java/com/alipay/sofa/rpc/registry/kubernetes/utils/KubernetesConfigUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes.utils;
+
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.RegistryConfig;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+
+import java.util.Base64;
+
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.API_VERSION;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CA_CERT_DATA;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CA_CERT_FILE;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CLIENT_CERT_DATA;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CLIENT_CERT_FILE;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CLIENT_KEY_ALGO;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CLIENT_KEY_DATA;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CLIENT_KEY_FILE;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CLIENT_KEY_PASSPHRASE;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.CONNECTION_TIMEOUT;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.DEFAULT_MASTER_URL;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.HTTP2_DISABLE;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.HTTPS_PROXY;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.HTTP_PROXY;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.LOGGING_INTERVAL;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.NAMESPACE;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.OAUTH_TOKEN;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.PASSWORD;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.PROXY_PASSWORD;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.PROXY_USERNAME;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.REQUEST_TIMEOUT;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.TRUST_CERTS;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.USERNAME;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.USE_HTTPS;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.WATCH_RECONNECT_INTERVAL;
+import static com.alipay.sofa.rpc.registry.kubernetes.constant.KubernetesClientConstants.WATCH_RECONNECT_LIMIT;
+
+public class KubernetesConfigUtils {
+
+    public static Config buildKubernetesConfig(RegistryConfig registryConfig) {
+
+        // Init default config
+        Config base = Config.autoConfigure(null);
+
+        return new ConfigBuilder(base)
+            .withMasterUrl(buildMasterUrl(registryConfig))
+            .withApiVersion(registryConfig.getParameter(API_VERSION, base.getApiVersion()))
+            .withNamespace(registryConfig.getParameter(NAMESPACE, base.getNamespace()))
+            .withUsername(registryConfig.getParameter(USERNAME, base.getUsername()))
+            .withPassword(registryConfig.getParameter(PASSWORD, base.getPassword()))
+            .withOauthToken(registryConfig.getParameter(OAUTH_TOKEN, base.getOauthToken()))
+            .withCaCertFile(registryConfig.getParameter(CA_CERT_FILE, base.getCaCertFile()))
+            .withCaCertData(registryConfig.getParameter(CA_CERT_DATA, decodeBase64(base.getCaCertData())))
+            .withClientKeyFile(registryConfig.getParameter(CLIENT_KEY_FILE, base.getClientKeyFile()))
+            .withClientKeyData(registryConfig.getParameter(CLIENT_KEY_DATA, decodeBase64(base.getClientKeyData())))
+            .withClientCertFile(registryConfig.getParameter(CLIENT_CERT_FILE, base.getClientCertFile()))
+            .withClientCertData(registryConfig.getParameter(CLIENT_CERT_DATA, decodeBase64(base.getClientCertData())))
+            .withClientKeyAlgo(registryConfig.getParameter(CLIENT_KEY_ALGO, base.getClientKeyAlgo()))
+            .withClientKeyPassphrase(registryConfig.getParameter(CLIENT_KEY_PASSPHRASE, base.getClientKeyPassphrase()))
+            .withConnectionTimeout(registryConfig.getParameter(CONNECTION_TIMEOUT, base.getConnectionTimeout()))
+            .withRequestTimeout(registryConfig.getParameter(REQUEST_TIMEOUT, base.getRequestTimeout()))
+            .withWatchReconnectInterval(
+                registryConfig.getParameter(WATCH_RECONNECT_INTERVAL, base.getWatchReconnectInterval()))
+            .withWatchReconnectLimit(registryConfig.getParameter(WATCH_RECONNECT_LIMIT, base.getWatchReconnectLimit()))
+            .withLoggingInterval(registryConfig.getParameter(LOGGING_INTERVAL, base.getLoggingInterval()))
+            .withTrustCerts(registryConfig.getParameter(TRUST_CERTS, base.isTrustCerts()))
+            .withHttp2Disable(registryConfig.getParameter(HTTP2_DISABLE, base.isHttp2Disable()))
+            .withHttpProxy(registryConfig.getParameter(HTTP_PROXY, base.getHttpProxy()))
+            .withHttpsProxy(registryConfig.getParameter(HTTPS_PROXY, base.getHttpsProxy()))
+            .withProxyUsername(registryConfig.getParameter(PROXY_USERNAME, base.getProxyUsername()))
+            .withProxyPassword(registryConfig.getParameter(PROXY_PASSWORD, base.getProxyPassword()))
+            .build();
+    }
+
+    private static String buildMasterUrl(RegistryConfig registryConfig) {
+        String address = registryConfig.getAddress();
+        if (StringUtils.isBlank(address)) {
+            return DEFAULT_MASTER_URL;
+        }
+        if (address.startsWith("http")) {
+            return address;
+        }
+        return registryConfig.getParameter(USE_HTTPS, true) ? "https://" + address : "http://" + address;
+    }
+
+    private static String decodeBase64(String str) {
+        return StringUtils.isNotEmpty(str) ? new String(Base64.getDecoder().decode(str)) : null;
+    }
+}

--- a/registry/registry-kubernetes/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.registry.Registry
+++ b/registry/registry-kubernetes/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.registry.Registry
@@ -1,0 +1,1 @@
+kubernetes=com.alipay.sofa.rpc.registry.kubernetes.KubernetesRegistry

--- a/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistryTest.java
+++ b/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/KubernetesRegistryTest.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+import com.alipay.sofa.rpc.client.ProviderGroup;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ApplicationConfig;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.RegistryConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.context.RpcInternalContext;
+import com.alipay.sofa.rpc.context.RpcInvokeContext;
+import com.alipay.sofa.rpc.context.RpcRunningState;
+import com.alipay.sofa.rpc.context.RpcRuntimeContext;
+import com.alipay.sofa.rpc.listener.ProviderInfoListener;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.alipay.sofa.rpc.registry.kubernetes.KubernetesRegistryHelper.buildDataId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class KubernetesRegistryTest {
+
+    private static final String NAMESPACE = "TestNameSpace";
+    private static final String POD_NAME = "TestPodName";
+    private static final String APP_NAME = "TestAppName";
+    private static final String SERVICE_NAME = "TestService";
+
+    public KubernetesServer mockServer;
+
+    private NamespacedKubernetesClient mockClient;
+
+    private static KubernetesRegistry kubernetesRegistry;
+
+    private static RegistryConfig registryConfig;
+
+    private static ConsumerConfig<?> consumer;
+
+    /**
+     * Ad before class.
+     */
+    @BeforeClass
+    public static void adBeforeClass() {
+        RpcRunningState.setUnitTestMode(true);
+    }
+
+    /**
+     * Ad after class.
+     */
+    @AfterClass
+    public static void adAfterClass() {
+        RpcRuntimeContext.destroy();
+        RpcInternalContext.removeContext();
+        RpcInvokeContext.removeContext();
+    }
+
+    @Before
+    public void setup() {
+        mockServer = new KubernetesServer(false, true);
+        mockServer.before();
+        mockClient = mockServer.getClient().inNamespace(NAMESPACE);
+
+        registryConfig = new RegistryConfig();
+        registryConfig.setProtocol("kubernetes");
+        registryConfig.setAddress(mockClient.getConfiguration().getMasterUrl());
+        //        registryConfig.setParameter("trustCerts", "true");
+        registryConfig.setParameter("namespace", NAMESPACE);
+        registryConfig.setParameter("useHttps", "false");
+        registryConfig.setParameter("http2Disable", "true");
+
+        kubernetesRegistry = new KubernetesRegistry(registryConfig);
+        kubernetesRegistry.init();
+        kubernetesRegistry.setCurrentHostname(POD_NAME);
+
+        System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+        System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                .withName(POD_NAME)
+                .endMetadata()
+                .withNewStatus()
+                .withPodIP("192.168.1.100")
+                .endStatus()
+                .build();
+
+        Service service = new ServiceBuilder()
+                .withNewMetadata()
+                .withName(SERVICE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+
+        Endpoints endPoints = new EndpointsBuilder()
+                .withNewMetadata()
+                .withName(SERVICE_NAME)
+                .endMetadata()
+                .addNewSubset()
+                .addNewAddress()
+                .withIp("ip1")
+                .withNewTargetRef()
+                .withUid("uid1")
+                .withName(POD_NAME)
+                .endTargetRef()
+                .endAddress()
+                .addNewPort("Test", "Test", 12345, "TCP")
+                .endSubset()
+                .build();
+
+        mockClient.pods().inNamespace(NAMESPACE).create(pod);
+        mockClient.services().inNamespace(NAMESPACE).create(service);
+        mockClient.endpoints().inNamespace(NAMESPACE).create(endPoints);
+
+        Assert.assertTrue(kubernetesRegistry.start());
+    }
+
+    @After
+    public void cleanup() {
+        kubernetesRegistry.destroy();
+        mockClient.close();
+        mockServer.after();
+    }
+
+    @Test
+    public void testAll() throws InterruptedException {
+        ApplicationConfig applicationConfig = new ApplicationConfig()
+                .setAppName(APP_NAME);
+
+        ServerConfig serverConfig1 = new ServerConfig()
+                .setProtocol("bolt")
+                .setPort(12200)
+                .setDaemon(false);
+
+        ProviderConfig<TestService> providerConfig1 = new ProviderConfig<TestService>()
+                .setApplication(applicationConfig)
+                .setInterfaceId(TestService.class.getName())
+                .setRegistry(registryConfig)
+                .setRegister(true)
+                //                .setUniqueId("standalone")
+                .setRef(new TestServiceImpl())
+                .setDelay(20)
+                .setServer(serverConfig1);
+
+        // 注册第一个providerConfig1
+        kubernetesRegistry.register(providerConfig1);
+
+        ServerConfig serverConfig2 = new ServerConfig()
+                .setProtocol("h2c")
+                .setPort(12202)
+                .setDaemon(false);
+
+        ProviderConfig<TestService2> providerConfig2 = new ProviderConfig<TestService2>()
+                .setApplication(applicationConfig)
+                .setInterfaceId(TestService2.class.getName())
+                .setRegistry(registryConfig)
+                .setRegister(true)
+                //                .setUniqueId("standalone")
+                .setRef(new TestServiceImpl2())
+                .setDelay(20)
+                .setServer(serverConfig2);
+
+        // 注册第二个providerConfig2
+        kubernetesRegistry.register(providerConfig2);
+
+        List<Pod> items = mockClient.pods().inNamespace(NAMESPACE).list().getItems();
+
+        Assert.assertEquals(1, items.size());
+        Pod pod = items.get(0);
+        String annotationBolt = pod.getMetadata().getAnnotations().get(buildDataId(providerConfig1, "bolt"));
+        Assert.assertNotNull(annotationBolt);
+        String annotationH2c = pod.getMetadata().getAnnotations().get(buildDataId(providerConfig2, "h2c"));
+        Assert.assertNotNull(annotationH2c);
+
+        // 订阅
+        consumer = new ConsumerConfig();
+        consumer.setInterfaceId("com.alipay.sofa.rpc.registry.kubernetes.TestService")
+                .setApplication(applicationConfig)
+                .setProxy("javassist")
+                .setSubscribe(true)
+                .setSerialization("java")
+                .setInvokeType("sync")
+                .setTimeout(4444);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        MockProviderInfoListener providerInfoListener = new MockProviderInfoListener();
+        providerInfoListener.setCountDownLatch(latch);
+        consumer.setProviderInfoListener(providerInfoListener);
+        List<ProviderGroup> all = kubernetesRegistry.subscribe(consumer);
+        providerInfoListener.updateAllProviders(all);
+        latch.await(5000, TimeUnit.MILLISECONDS);
+        Map<String, ProviderGroup> ps = providerInfoListener.getData();
+
+        Assert.assertEquals(1, kubernetesRegistry.getConsumerListeners().size());
+        Assert.assertTrue(ps.size() > 0);
+        Assert.assertEquals(1, ps.size());
+        Assert.assertNotNull(ps.get(RpcConstants.ADDRESS_DEFAULT_GROUP));
+        Assert.assertTrue(ps.get(RpcConstants.ADDRESS_DEFAULT_GROUP).size() > 0);
+
+        // 一次发2个端口的再次注册
+        latch = new CountDownLatch(2);
+        providerInfoListener.setCountDownLatch(latch);
+        ServerConfig serverConfig = new ServerConfig()
+                .setProtocol("bolt")
+                .setHost("0.0.0.0")
+                .setDaemon(false)
+                .setPort(12201);
+        providerConfig1.getServer().add(serverConfig);
+        kubernetesRegistry.register(providerConfig1);
+        latch.await(5000 * 2, TimeUnit.MILLISECONDS);
+        Assert.assertTrue(ps.size() > 0);
+        Assert.assertNotNull(ps.get(RpcConstants.ADDRESS_DEFAULT_GROUP));
+        Assert.assertEquals(1, ps.get(RpcConstants.ADDRESS_DEFAULT_GROUP).size());
+
+        // 反订阅
+        kubernetesRegistry.unSubscribe(consumer);
+        Assert.assertEquals(0, kubernetesRegistry.getConsumerListeners().size());
+
+        // 反注册providerConfig1
+        kubernetesRegistry.unRegister(providerConfig1);
+        // 反注册providerConfig2
+        kubernetesRegistry.unRegister(providerConfig2);
+
+        List<Pod> unRegisterItems = mockClient.pods().inNamespace(NAMESPACE).list().getItems();
+        Assert.assertEquals(0, unRegisterItems.get(0).getMetadata().getAnnotations().size());
+    }
+
+    private static class MockProviderInfoListener implements ProviderInfoListener {
+
+        Map<String, ProviderGroup> providerGroupMap = new HashMap<>();
+
+        private CountDownLatch countDownLatch;
+
+        public void setCountDownLatch(CountDownLatch countDownLatch) {
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public void addProvider(ProviderGroup providerGroup) {
+
+        }
+
+        @Override
+        public void removeProvider(ProviderGroup providerGroup) {
+
+        }
+
+        @Override
+        public void updateProviders(ProviderGroup providerGroup) {
+
+            providerGroupMap.put(providerGroup.getName(), providerGroup);
+            if (countDownLatch != null) {
+                countDownLatch.countDown();
+                countDownLatch = null;
+            }
+        }
+
+        @Override
+        public void updateAllProviders(List<ProviderGroup> providerGroups) {
+            providerGroupMap.clear();
+
+            if (providerGroups == null || providerGroups.size() == 0) {
+            } else {
+                for (ProviderGroup p : providerGroups) {
+                    providerGroupMap.put(p.getName(), p);
+                }
+
+            }
+        }
+
+        public Map<String, ProviderGroup> getData() {
+            return providerGroupMap;
+        }
+    }
+
+    @Test
+    public void testUpdatePodAnnotations() {
+
+        // 创建一个新的 Pod
+        String podName = "test-pod";
+        String namespace = "test-namespace";
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                .withName(podName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .build();
+
+        // 在模拟环境中创建 Pod
+        pod = mockClient.pods().inNamespace(namespace).create(pod);
+        assertNotNull(pod);
+
+        // 准备要更新的 annotations
+        Map<String, String> annotations = new HashMap<>();
+        annotations.put("example.com/annotation", "value");
+
+        // 更新 Pod 的 annotations
+        pod = new PodBuilder(pod)
+                .editMetadata()
+                .addToAnnotations(annotations)
+                .endMetadata()
+                .build();
+
+        // 在模拟环境中更新 Pod
+        pod = mockClient.pods().inNamespace(namespace).withName(podName).replace(pod);
+
+        // 获取并验证 annotations 是否已更新
+        assertEquals("value", pod.getMetadata().getAnnotations().get("example.com/annotation"));
+    }
+}

--- a/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestService.java
+++ b/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestService.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+public interface TestService {
+
+    String sayHello(String str);
+}

--- a/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestService2.java
+++ b/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestService2.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+public interface TestService2 {
+
+    String sayHello(String str);
+}

--- a/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestServiceImpl.java
+++ b/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+public class TestServiceImpl implements TestService {
+
+    @Override
+    public String sayHello(String str) {
+        return str;
+    }
+}

--- a/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestServiceImpl2.java
+++ b/registry/registry-kubernetes/src/test/java/com/alipay/sofa/rpc/registry/kubernetes/TestServiceImpl2.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.registry.kubernetes;
+
+public class TestServiceImpl2 implements TestService2 {
+
+    @Override
+    public String sayHello(String str) {
+        return str;
+    }
+}

--- a/registry/registry-kubernetes/src/test/resources/log4j.xml
+++ b/registry/registry-kubernetes/src/test/resources/log4j.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d %t %5p [%c:%M:%L] - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</log4j:configuration>

--- a/registry/registry-kubernetes/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/registry/registry-kubernetes/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/registry/registry-kubernetes/src/test/resources/sofa-rpc/rpc-config.json
+++ b/registry/registry-kubernetes/src/test/resources/sofa-rpc/rpc-config.json
@@ -1,0 +1,4 @@
+{
+  "rpc.config.order": 999,  // 加载顺序，越大越后加载
+  "logger.impl" : "com.alipay.sofa.rpc.log.SLF4JLoggerImpl"
+}


### PR DESCRIPTION
# 总体设计

![image](https://github.com/sofastack/sofa-rpc/assets/17539174/47f8c57c-934c-426c-ae91-99c2cd01f8e6)

# 样例
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
   com.alipay.sofa.rpc.registry.kubernetes.TestService:1.0@DEFAULT: 'bolt://192.168.1.100:12200?accepts=100000&appName=TestAppName&weight=100&language=java&pid=41517&interface=com.alipay.sofa.rpc.registry.kubernetes.TestService&timeout=0&serialization=hessian2&protocol=bolt&delay=20&dynamic=true&startTime=1711021435028&id=rpc-cfg-0&uniqueId=&rpcVer=51300'
  creationTimestamp: "2024-02-02T08:47:54Z"
  generateName: sofa-rpc-k8s-provider-86f8565dcb-
  labels:
    com.alipay.sofa.rpc.registry.kubernetes.TestService:1.0@DEFAULT: ''
    app: sofa-rpc-k8s-provider
    pod-template-hash: 86f8565dcb
  name: sofa-rpc-k8s-provider-86f8565dcb-m7r6v
  namespace: sofa-rpc-k8s
```

# 环境准备
1. 安装docker
https://www.docker.com/
2. 安装minikube
https://kubernetes.io/zh-cn/docs/tutorials/hello-minikube/

# 代码准备
https://github.com/wangchengming666/sofa-rpc-registry-kubernetes-demo

# 测试手法
## Provider部分
1. 打包provider的镜像
`docker build -t sofa-rpc-k8s-provider:1.0.0 .`
2. 加载镜像
`minikube image load sofa-rpc-k8s-provider:1.0.0  `
3. apply sa
`kubectl apply -f ServiceAccount.yml  `
4. apply Deployment
`kubectl apply -f Deployment.yml  `
5. 查看provider的pod
`kubectl get pods -n sofa-rpc-k8s `

```
chengming@chengmingdeMacBook-Pro k8s % kubectl get pods -n sofa-rpc-k8s                                          
NAME                                     READY   STATUS    RESTARTS   AGE
sofa-rpc-k8s-provider-86f8565dcb-9z7hw   1/1     Running   0          7s
sofa-rpc-k8s-provider-86f8565dcb-jw4wg   1/1     Running   0          7s
sofa-rpc-k8s-provider-86f8565dcb-m7r6v   1/1     Running   0          7s
```
6. 查看provider的日志
`kubectl logs -f sofa-rpc-k8s-provider-86f8565dcb-m7r6v  -n sofa-rpc-k8s  `

```
chengming@chengmingdeMacBook-Pro k8s % kubectl logs -f sofa-rpc-k8s-provider-86f8565dcb-m7r6v  -n sofa-rpc-k8s    

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::               (v2.4.13)

2024-02-02 08:48:02.078  INFO 1 --- [           main] com.example.appboot.AppbootApplication   : Starting AppbootApplication v0.0.1-SNAPSHOT using Java 1.8.0_342 on sofa-rpc-k8s-provider-86f8565dcb-m7r6v with PID 1 (/app/appboot-0.0.1-SNAPSHOT.jar started by root in /app)
2024-02-02 08:48:02.098  INFO 1 --- [           main] com.example.appboot.AppbootApplication   : No active profile set, falling back to default profiles: default
2024-02-02 08:48:12.561  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
2024-02-02 08:48:12.753  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2024-02-02 08:48:12.757  INFO 1 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.55]
2024-02-02 08:48:13.470  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/myapp]  : Initializing Spring embedded WebApplicationContext
2024-02-02 08:48:13.470  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 10590 ms
2024-02-02 08:48:17.359  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path '/myapp'
2024-02-02 08:48:17.380  INFO 1 --- [           main] com.example.appboot.AppbootApplication   : Started AppbootApplication in 18.826 seconds (JVM running for 21.29)
AppbootApplication start
AppbootApplication start success

```

## Consumer部分
1. 打包consumer的镜像
` docker build -t sofa-rpc-k8s-consumer:1.0.0 .`
2. 加载镜像
`minikube image load sofa-rpc-k8s-consumer:1.0.0  `
3. apply Deployment
`kubectl apply -f Deployment.yml  `
4. 查看consumer的pod
`kubectl get pods -n sofa-rpc-k8s `

```
chengming@chengmingdeMacBook-Pro k8s % kubectl get pods -n sofa-rpc-k8s                                                      
NAME                                     READY   STATUS    RESTARTS   AGE
sofa-rpc-k8s-consumer-5d6cd8698d-pf7wd   1/1     Running   0          4s
```
5. 查看consumer的日志
`kubectl logs -f sofa-rpc-k8s-consumer-5d6cd8698d-pf7wd -n sofa-rpc-k8s `

```
chengming@chengmingdeMacBook-Pro k8s % kubectl logs -f sofa-rpc-k8s-consumer-5d6cd8698d-pf7wd -n sofa-rpc-k8s   
Listening for transport dt_socket at address: 5005

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::               (v2.4.13)

2024-02-02 08:58:31.304  INFO 1 --- [           main] c.s.e.s.SofaRpcK8sConsumerApplication    : Starting SofaRpcK8sConsumerApplication v0.0.1-SNAPSHOT using Java 1.8.0_342 on sofa-rpc-k8s-consumer-5d6cd8698d-pf7wd with PID 1 (/app/sofa-rpc-k8s-consumer-0.0.1-SNAPSHOT.jar started by root in /app)
2024-02-02 08:58:31.308  INFO 1 --- [           main] c.s.e.s.SofaRpcK8sConsumerApplication    : No active profile set, falling back to default profiles: default
2024-02-02 08:58:34.300  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8082 (http)
2024-02-02 08:58:34.320  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2024-02-02 08:58:34.320  INFO 1 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.55]
2024-02-02 08:58:34.590  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/myapp]  : Initializing Spring embedded WebApplicationContext
2024-02-02 08:58:34.590  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 3165 ms
2024-02-02 08:58:36.019  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8082 (http) with context path '/myapp'
2024-02-02 08:58:36.077  INFO 1 --- [           main] c.s.e.s.SofaRpcK8sConsumerApplication    : Started SofaRpcK8sConsumerApplication in 5.676 seconds (JVM running for 6.578)
```
6. 发起调用，在控制台可以看到如下日志，代表调用成功
```
start call sofa-rpc-k8s-provider
2024-02-04 02:12:40.364  WARN 1 --- [           main] io.fury.config.FuryBuilder               : Class registration isn't forced, unknown classes can be deserialized. If the environment isn't secure, please enable class registration by `FuryBuilder#requireClassRegistration(true)` or configure ClassChecker by `ClassResolver#setClassChecker`
2024-02-04 02:12:41.593  INFO 1 --- [           main] io.fury.Fury                             : Created new fury io.fury.Fury@4d02f94e
2024-02-04 02:12:41.675  WARN 1 --- [           main] .c.h.i.AbstractStringBuilderDeserializer : coder field not found or not accessible, will skip coder check, error is coder
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
call provider success chengming
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced Kubernetes registry support for service registration and discovery.
	- Added utility classes for Kubernetes client configuration and interaction.
	- Enhanced `RegistryConfig` with methods to retrieve parameters with default values.
- **Tests**
	- Added tests for Kubernetes registry functionality, including service registration and discovery.
- **Documentation**
	- Added documentation entries for Kubernetes registry support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->