### PR TITLE
Optimize performance for h2c protocol

### DIFF
--- a/core/common/src/main/java/com/alipay/sofa/rpc/common/BatchExecutorQueue.java
+++ b/core/common/src/main/java/com/alipay/sofa/rpc/common/BatchExecutorQueue.java
@@ -31,8 +31,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class BatchExecutorQueue<T> {
 
     static final int            DEFAULT_QUEUE_SIZE = 128;
+
     private final Queue<T>      queue;
+
     private final AtomicBoolean scheduled;
+
     private final int           chunkSize;
 
     public BatchExecutorQueue() {
@@ -56,7 +59,7 @@ public class BatchExecutorQueue<T> {
         }
     }
 
-    private void run(Executor executor) {
+    void run(Executor executor) {
         try {
             Queue<T> snapshot = new LinkedList<>();
             T item;
@@ -94,5 +97,23 @@ public class BatchExecutorQueue<T> {
     }
 
     protected void flush(T item) {
+    }
+
+    /**
+     * UT only
+     * @return
+     */
+    @Deprecated
+    public AtomicBoolean getScheduled() {
+        return scheduled;
+    }
+
+    /**
+     * UT only
+     * @return
+     */
+    @Deprecated
+    public Queue<T> getQueue() {
+        return queue;
     }
 }

--- a/core/common/src/main/java/com/alipay/sofa/rpc/common/BatchExecutorQueue.java
+++ b/core/common/src/main/java/com/alipay/sofa/rpc/common/BatchExecutorQueue.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.common;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 批量执行队列
+ *
+ * @author chengming
+ * @version BatchExecutorQueue.java, v 0.1 2024年02月28日 5:36 PM chengming
+ */
+public class BatchExecutorQueue<T> {
+
+    static final int            DEFAULT_QUEUE_SIZE = 128;
+    private final Queue<T>      queue;
+    private final AtomicBoolean scheduled;
+    private final int           chunkSize;
+
+    public BatchExecutorQueue() {
+        this(DEFAULT_QUEUE_SIZE);
+    }
+
+    public BatchExecutorQueue(int chunkSize) {
+        this.queue = new ConcurrentLinkedQueue<>();
+        this.scheduled = new AtomicBoolean(false);
+        this.chunkSize = chunkSize;
+    }
+
+    public void enqueue(T message, Executor executor) {
+        queue.add(message);
+        scheduleFlush(executor);
+    }
+
+    protected void scheduleFlush(Executor executor) {
+        if (scheduled.compareAndSet(false, true)) {
+            executor.execute(() -> this.run(executor));
+        }
+    }
+
+    private void run(Executor executor) {
+        try {
+            Queue<T> snapshot = new LinkedList<>();
+            T item;
+            while ((item = queue.poll()) != null) {
+                snapshot.add(item);
+            }
+            int i = 0;
+            boolean flushedOnce = false;
+            while ((item = snapshot.poll()) != null) {
+                if (snapshot.size() == 0) {
+                    flushedOnce = false;
+                    break;
+                }
+                if (i == chunkSize) {
+                    i = 0;
+                    flush(item);
+                    flushedOnce = true;
+                } else {
+                    prepare(item);
+                    i++;
+                }
+            }
+            if ((i != 0 || !flushedOnce) && item != null) {
+                flush(item);
+            }
+        } finally {
+            scheduled.set(false);
+            if (!queue.isEmpty()) {
+                scheduleFlush(executor);
+            }
+        }
+    }
+
+    protected void prepare(T item) {
+    }
+
+    protected void flush(T item) {
+    }
+}

--- a/core/common/src/test/java/com/alipay/sofa/rpc/common/BatchExecutorQueueTest.java
+++ b/core/common/src/test/java/com/alipay/sofa/rpc/common/BatchExecutorQueueTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author chengming
+ * @version BatchExecutorQueueTest.java, v 0.1 2024年03月01日 10:55 AM chengming
+ */
+public class BatchExecutorQueueTest {
+
+    private BatchExecutorQueue<Object> batchExecutorQueue;
+
+    @Mock
+    private Executor                   mockExecutor;
+
+    @Captor
+    private ArgumentCaptor<Runnable>   runnableCaptor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        batchExecutorQueue = spy(new BatchExecutorQueue<>(2));
+    }
+
+    @Test
+    public void testEnqueueAndRun() {
+        Object message1 = new Object();
+        Object message2 = new Object();
+        Object message3 = new Object();
+
+        // 测试 enqueue 方法以及是否通过 executor 调度了 run 方法
+        batchExecutorQueue.enqueue(message1, mockExecutor);
+        batchExecutorQueue.enqueue(message2, mockExecutor);
+        batchExecutorQueue.enqueue(message3, mockExecutor);
+
+        verify(mockExecutor, atLeastOnce()).execute(runnableCaptor.capture());
+
+        Runnable scheduledRunnable = runnableCaptor.getValue();
+        Assert.assertNotNull(scheduledRunnable);
+        scheduledRunnable.run();
+
+        // 验证队列是否为空
+        Assert.assertTrue(batchExecutorQueue.getQueue().isEmpty());
+    }
+
+    @Test
+    public void testScheduleFlush() {
+        AtomicBoolean scheduled = batchExecutorQueue.getScheduled();
+        Assert.assertFalse(scheduled.get());
+
+        batchExecutorQueue.scheduleFlush(mockExecutor);
+        Assert.assertTrue(scheduled.get());
+
+        // 验证是否有任务提交到 executor
+        verify(mockExecutor).execute(any(Runnable.class));
+    }
+
+}

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/netty/NettyBatchWriteQueue.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/netty/NettyBatchWriteQueue.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.transport.netty;
+
+import com.alipay.sofa.rpc.common.BatchExecutorQueue;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+
+/**
+ * @author chengming
+ * @version NettyBatchWriteQueue.java, v 0.1 2024年02月28日 5:42 PM chengming
+ */
+public class NettyBatchWriteQueue extends BatchExecutorQueue<NettyBatchWriteQueue.MessageTuple> {
+
+    private final Channel   channel;
+
+    private final EventLoop eventLoop;
+
+    private NettyBatchWriteQueue(Channel channel) {
+        this.channel = channel;
+        this.eventLoop = channel.eventLoop();
+    }
+
+    public ChannelFuture enqueue(Object message) {
+        return enqueue(message, channel.newPromise());
+    }
+
+    public ChannelFuture enqueue(Object message, ChannelPromise channelPromise) {
+        MessageTuple messageTuple = new MessageTuple(message, channelPromise);
+        super.enqueue(messageTuple, eventLoop);
+        return messageTuple.channelPromise;
+    }
+
+    @Override
+    protected void prepare(MessageTuple item) {
+        channel.write(item.originMessage, item.channelPromise);
+    }
+
+    @Override
+    protected void flush(MessageTuple item) {
+        prepare(item);
+        channel.flush();
+    }
+
+    public static NettyBatchWriteQueue createWriteQueue(Channel channel) {
+        return new NettyBatchWriteQueue(channel);
+    }
+
+    static class MessageTuple {
+
+        private final Object         originMessage;
+
+        private final ChannelPromise channelPromise;
+
+        public MessageTuple(Object originMessage, ChannelPromise channelPromise) {
+            this.originMessage = originMessage;
+            this.channelPromise = channelPromise;
+        }
+    }
+}

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/netty/NettyChannel.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/netty/NettyChannel.java
@@ -48,8 +48,11 @@ public class NettyChannel extends AbstractChannel<ChannelHandlerContext, Channel
      */
     private Channel               channel;
 
+    private NettyBatchWriteQueue  writeQueue;
+
     public NettyChannel(Channel channel) {
         this.channel = channel;
+        this.writeQueue = NettyBatchWriteQueue.createWriteQueue(channel);
     }
 
     public NettyChannel(ChannelHandlerContext context) {
@@ -79,17 +82,14 @@ public class NettyChannel extends AbstractChannel<ChannelHandlerContext, Channel
 
     @Override
     public void writeAndFlush(final Object obj) {
-        Future future = channel.writeAndFlush(obj);
-        future.addListener(new FutureListener() {
-            @Override
-            public void operationComplete(Future future1) throws Exception {
-                if (!future1.isSuccess()) {
-                    Throwable throwable = future1.cause();
-                    LOGGER.error("Failed to send to "
-                        + NetUtils.channelToString(localAddress(), remoteAddress())
-                        + " for msg : " + obj
-                        + ", Cause by:", throwable);
-                }
+        Future future = writeQueue.enqueue(obj);
+        future.addListener((FutureListener) future1 -> {
+            if (!future1.isSuccess()) {
+                Throwable throwable = future1.cause();
+                LOGGER.error("Failed to send to "
+                    + NetUtils.channelToString(localAddress(), remoteAddress())
+                    + " for msg : " + obj
+                    + ", Cause by:", throwable);
             }
         });
     }

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/netty/NettyChannel.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/netty/NettyChannel.java
@@ -98,4 +98,14 @@ public class NettyChannel extends AbstractChannel<ChannelHandlerContext, Channel
     public boolean isAvailable() {
         return channel.isOpen() && channel.isActive();
     }
+
+    /**
+     * UT only
+     * @param writeQueue
+     */
+    @Deprecated
+    public void setWriteQueue(NettyBatchWriteQueue writeQueue) {
+        this.writeQueue = writeQueue;
+    }
+
 }

--- a/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyBatchWriteQueueTest.java
+++ b/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyBatchWriteQueueTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.transport.netty;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author chengming
+ * @version NettyBatchWriteQueueTest.java, v 0.1 2024年03月01日 11:06 AM chengming
+ */
+public class NettyBatchWriteQueueTest {
+
+    @Mock
+    private Channel              mockChannel;
+
+    @Mock
+    private EventLoop            mockEventLoop;
+
+    @Mock
+    private ChannelPromise       mockChannelPromise;
+
+    private NettyBatchWriteQueue nettyBatchWriteQueue;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
+        when(mockChannel.newPromise()).thenReturn(mockChannelPromise);
+        nettyBatchWriteQueue = NettyBatchWriteQueue.createWriteQueue(mockChannel);
+    }
+
+    @Test
+    public void testEnqueue() {
+        Object message = new Object();
+        ChannelFuture future = nettyBatchWriteQueue.enqueue(message);
+        Assert.assertNotNull(future);
+
+        Mockito.verify(mockEventLoop).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void testPrepare() {
+        Object message = new Object();
+        NettyBatchWriteQueue.MessageTuple messageTuple = new NettyBatchWriteQueue.MessageTuple(message,
+            mockChannelPromise);
+        nettyBatchWriteQueue.prepare(messageTuple);
+
+        Mockito.verify(mockChannel).write(eq(message), eq(mockChannelPromise));
+    }
+
+    @Test
+    public void testFlush() {
+        Object message = new Object();
+        NettyBatchWriteQueue.MessageTuple messageTuple = new NettyBatchWriteQueue.MessageTuple(message,
+            mockChannelPromise);
+        nettyBatchWriteQueue.flush(messageTuple);
+
+        Mockito.verify(mockChannel).write(eq(message), eq(mockChannelPromise));
+        Mockito.verify(mockChannel).flush();
+    }
+}

--- a/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyChannelTest.java
+++ b/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyChannelTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.transport.netty;
+
+import com.alipay.sofa.rpc.common.utils.NetUtils;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.net.InetSocketAddress;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author chengming
+ * @version NettyChannelTest.java, v 0.1 2024年02月29日 3:18 PM chengming
+ */
+public class NettyChannelTest {
+
+    @Mock
+    private Channel               mockChannel    = Mockito.mock(Channel.class);
+
+    @Mock
+    private ChannelHandlerContext mockContext    = Mockito.mock(ChannelHandlerContext.class);
+
+    @Mock
+    private NettyBatchWriteQueue  mockWriteQueue = Mockito.mock(NettyBatchWriteQueue.class);
+
+    @Mock
+    private ChannelFuture         mockFuture     = Mockito.mock(ChannelFuture.class);
+
+    private NettyChannel          nettyChannel;
+
+    @Before
+    public void setUp() {
+        Mockito.when(mockChannel.eventLoop()).thenReturn(Mockito.mock(EventLoop.class));
+        Mockito.when(mockChannel.alloc()).thenReturn(PooledByteBufAllocator.DEFAULT);
+        when(mockContext.channel()).thenReturn(mockChannel);
+        when(mockWriteQueue.enqueue(any())).thenReturn(mockFuture);
+        nettyChannel = new NettyChannel(mockChannel);
+        nettyChannel.setWriteQueue(mockWriteQueue);
+    }
+
+    @Test
+    public void testRunSuccess() throws Exception {
+        nettyChannel.writeAndFlush("111");
+
+        Mockito.verify(mockWriteQueue).enqueue("111");
+
+        ArgumentCaptor<GenericFutureListener> captor = ArgumentCaptor.forClass(GenericFutureListener.class);
+        Mockito.verify(mockFuture).addListener(captor.capture());
+
+        // 模拟 FutureListener 的回调
+        GenericFutureListener<Future<Object>> listener = captor.getValue();
+        listener.operationComplete((Future) mockFuture);
+
+        // 验证没有错误日志被记录（因为操作是成功的）
+        Mockito.verify(Mockito.mock(NetUtils.class), times(10));
+        NetUtils.channelToString(any(InetSocketAddress.class), any(InetSocketAddress.class));
+    }
+
+}


### PR DESCRIPTION
# 优化效果

- 环境信息：

MacOS 13.3.1 (a) (22E772610a)
六核Intel Core i7  16G
mac OS 10.15.7
JDK 1.8.0_291
VM version: JDK 1.8.0_291, Java HotSpot(TM) 64-Bit Server VM, 25.291-b10
VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_291.jdk/Contents/Home/jre/bin/java
VM options: -Xmx1g -Xms1g -XX:MaxDirectMemorySize=4g -XX:+UseG1GC -Djmh.ignoreLock=true -Dserver.host=localhost -Dserver.port=12200 -Dbenchmark.output=
Blackhole mode: full + dont-inline hint
Warmup: 1 iterations, 10 s each
Measurement: 1 iterations, 300 s each
Timeout: 10 min per iteration
Threads: 1000 threads, will synchronize iterations
Benchmark mode: Throughput, ops/time
Benchmark: com.alipay.sofa.benchmark.Client.existUser


- 优化前
```
Benchmark          Mode  Cnt      Score   Error  Units
Client.existUser  thrpt       12858.680          ops/s
```
- 优化后
```
Benchmark          Mode  Cnt      Score   Error  Units
Client.existUser  thrpt       15031.383          ops/s
```

# 思路
在当前`com.alipay.sofa.rpc.transport.netty.NettyChannel#writeAndFlush`的代码如下

```
@Override
    public void writeAndFlush(final Object obj) {
       //  直接调用channel的writeAndFlush
       Future future = channel.writeAndFlush(obj); 
        future.addListener(new FutureListener() {
            @Override
            public void operationComplete(Future future1) throws Exception {
                if (!future1.isSuccess()) {
                    Throwable throwable = future1.cause();
                    LOGGER.error("Failed to send to "
                        + NetUtils.channelToString(localAddress(), remoteAddress())
                        + " for msg : " + obj
                        + ", Cause by:", throwable);
                }
            }
        });
    }
```

在Netty4+的版本我们通过源码可以看到，当调用channel的writeAndFlush方法时，Netty4会判断当前发送请求的线程是否是当前channel所绑定的EventLoop线程，如果不是EventLooop则会构造一个写任务WriteTask并将其提交到EventLoop中稍后执行。

```
private void write(Object msg, boolean flush, ChannelPromise promise) {
       //  忽略
        final AbstractChannelHandlerContext next = findContextOutbound(flush ?
                (MASK_WRITE | MASK_FLUSH) : MASK_WRITE);
        final Object m = pipeline.touch(msg, next);
        EventExecutor executor = next.executor();
  	//  判断当前线程是否是该channel绑定的EventLoop
        if (executor.inEventLoop()) {
            if (flush) {
                next.invokeWriteAndFlush(m, promise);
            } else {
                next.invokeWrite(m, promise);
            }
        } else {
            final WriteTask task = WriteTask.newInstance(next, m, promise, flush);
            //  将写任务提交到EventLoop上稍后执行
            if (!safeExecute(executor, task, promise, m, !flush)) {
                task.cancel();
            }
        }
    }
```
从上面的代码我们可以知道Netty4写消息时总是会保证把任务提交到EventLoop线程上处理，而`每调度一次EventLoop线程去执行写任务WriteTask只能写一个消息`，也就是这时候是一对一的。

那么这个时候我们可以考虑将所有的消息都先提交到一个WriteQueue消息写队列上，内部会获取一次EventLoop并提交一个任务，然后从消息队列上不断的取消息出来并调用Netty4的write。

`com.alipay.sofa.rpc.common.BatchExecutorQueue#run`部分代码

```
    private void run(Executor executor) {
        try {
            Queue<T> snapshot = new LinkedList<>();
            T item;
            while ((item = queue.poll()) != null) {
                snapshot.add(item);
            }
            int i = 0;
            boolean flushedOnce = false;
            while ((item = snapshot.poll()) != null) {
                if (snapshot.size() == 0) {
                    flushedOnce = false;
                    break;
                }
                if (i == chunkSize) {
                    i = 0;
                    flush(item);
                    flushedOnce = true;
                } else {
                    prepare(item);
                    i++;
                }
            }
            if ((i != 0 || !flushedOnce) && item != null) {
                flush(item);
            }
        } finally {
            scheduled.set(false);
            if (!queue.isEmpty()) {
                scheduleFlush(executor);
            }
        }
    }
```

执行该flush的逻辑时，是处于EventLoop线程的，而从前面的Netty源码我们知道，当写动作处于EventLoop线程中时是会立即执行写动作的，此时不会出现线程切换的行为。那么相较于之前每次都直接在用户线程中调用writeAndFlush而言，大幅度的减少了用户线程与EventLoop线程的切换次数，也使得一次WriteTask写出的消息数量有了大幅度提高，达到批量发包的效果。

示意图如下

![image](https://github.com/sofastack/sofa-rpc/assets/17539174/afe5f131-58da-48d3-9639-aeabf457f2c1)

