### PR TITLE
enhance: bump hessian from 3.5.2 to 3.5.3

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -59,7 +59,7 @@
         <sofa.common.tools.version>1.3.15</sofa.common.tools.version>
         <javassist.version>3.29.2-GA</javassist.version>
         <netty.version>4.1.44.Final</netty.version>
-        <hessian.version>3.5.2</hessian.version>
+        <hessian.version>3.5.3</hessian.version>
         <resteasy.version>3.6.3.Final</resteasy.version>
         <bolt.version>1.6.6</bolt.version>
         <tracer.version>3.0.8</tracer.version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,7 +32,7 @@
         <guava.version>32.0.0-jre</guava.version>
         <prometheus.client.version>0.16.0</prometheus.client.version>
         <!-- serialization -->
-        <hessian.version>3.5.2</hessian.version>
+        <hessian.version>3.5.3</hessian.version>
         <thrift.version>0.9.2</thrift.version>
         <protobuf.version>3.22.0</protobuf.version>
         <jackson.version>2.12.7</jackson.version>


### PR DESCRIPTION
### Motivation:

bump hessian to 3.5.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Hessian library version to `3.5.3` for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->