### PR TITLE
support default filter config

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcOptions.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcOptions.java
@@ -122,6 +122,10 @@ public class RpcOptions {
      * 默认Tracer实现
      */
     public static final String DEFAULT_TRACER                           = "default.tracer";
+    /**
+     * 默认filter实现
+     */
+    public static final String DEFAULT_FILTERS                          = "default.filters";
 
     /**
      * 注册中心发现服务（保存注册中心地址的服务）的地址

--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/AbstractInterfaceConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/AbstractInterfaceConfig.java
@@ -42,7 +42,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.alipay.sofa.rpc.common.RpcConfigs.getBooleanValue;
+import static com.alipay.sofa.rpc.common.RpcConfigs.getListValue;
 import static com.alipay.sofa.rpc.common.RpcConfigs.getStringValue;
+import static com.alipay.sofa.rpc.common.RpcOptions.DEFAULT_FILTERS;
 import static com.alipay.sofa.rpc.common.RpcOptions.DEFAULT_GROUP;
 import static com.alipay.sofa.rpc.common.RpcOptions.DEFAULT_PROXY;
 import static com.alipay.sofa.rpc.common.RpcOptions.DEFAULT_SERIALIZATION;
@@ -106,7 +108,8 @@ public abstract class AbstractInterfaceConfig<T, S extends AbstractInterfaceConf
     /**
      * 过滤器配置别名，多个用逗号隔开
      */
-    protected List<String>                           filter;
+    protected List<String>                           filter           = new ArrayList<String>(
+                                                                          getListValue(DEFAULT_FILTERS));
 
     /**
      * 注册中心配置，可配置多个
@@ -359,6 +362,18 @@ public abstract class AbstractInterfaceConfig<T, S extends AbstractInterfaceConf
     public S setFilter(List<String> filter) {
         this.filter = filter;
         return castThis();
+    }
+
+    /**
+     * add filter
+     *
+     * @param filter the add filter
+     */
+    public void addFilter(List<String> filter) {
+        if(this.filter == null) {
+            filter = new ArrayList<>();
+        }
+        this.filter.addAll(filter);
     }
 
     /**

--- a/core/api/src/test/java/com/alipay/sofa/rpc/filter/FilterChainTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/filter/FilterChainTest.java
@@ -25,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 
 /**
  *
@@ -38,12 +37,10 @@ public class FilterChainTest {
     public void buildProviderChain() {
 
         ProviderConfig providerConfig = new ProviderConfig();
-        providerConfig.setFilter(Arrays.asList("testChainFilter0", "-testChainFilter8"));
         providerConfig.setInterfaceId(Serializer.class.getName());
 
         ConsumerConfig consumerConfig = new ConsumerConfig();
         ArrayList<Filter> list = new ArrayList<Filter>();
-        consumerConfig.setFilter(Arrays.asList("testChainFilter0", "-testChainFilter8"));
         list.add(new TestChainFilter1());
         list.add(new TestChainFilter2());
         list.add(new TestChainFilter3());

--- a/core/api/src/test/java/com/alipay/sofa/rpc/std/config/AbstractInterfaceConfigTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/std/config/AbstractInterfaceConfigTest.java
@@ -58,7 +58,7 @@ public class AbstractInterfaceConfigTest {
         assertEquals(null, defaultConfig.getInterfaceId());
         assertEquals("", defaultConfig.getUniqueId());
         assertEquals(null, defaultConfig.getFilterRef());
-        assertEquals(null, defaultConfig.getFilter());
+        assertNotNull(defaultConfig.getFilter());
         assertEquals(null, defaultConfig.getRegistry());
         assertEquals(null, defaultConfig.getMethods());
         assertEquals("hessian2", defaultConfig.getSerialization());
@@ -122,9 +122,18 @@ public class AbstractInterfaceConfigTest {
         config.setFilterRef(filterRefList);
         assertSame(filterRefList, config.getFilterRef());
 
+        List<String> defaultFilter = config.getFilter();
         List<String> filterList = new ArrayList<>();
+        filterList.add("testFilter");
+        config.addFilter(filterList);
+        Assert.assertTrue(defaultFilter.contains("testChainFilter0"));
+        Assert.assertTrue(defaultFilter.contains("-testChainFilter8"));
+        Assert.assertTrue(defaultFilter.contains("testFilter"));
+        assertSame(defaultFilter, config.getFilter());
+
         config.setFilter(filterList);
         assertSame(filterList, config.getFilter());
+        assertNotSame(defaultFilter, config.getFilter());
 
         List<RegistryConfig> registryConfigs = new ArrayList<>();
         config.setRegistry(registryConfigs);

--- a/core/api/src/test/resources/sofa-rpc/rpc-config.json
+++ b/core/api/src/test/resources/sofa-rpc/rpc-config.json
@@ -1,4 +1,5 @@
 {
   "rpc.config.order": 999,
-  "logger.impl": "com.alipay.sofa.rpc.log.SystemLogger"
+  "logger.impl": "com.alipay.sofa.rpc.log.SystemLogger",
+  "default.filters" :["testChainFilter0", "-testChainFilter8"]
 }

--- a/core/common/src/main/resources/com/alipay/sofa/rpc/common/rpc-config-default.json
+++ b/core/common/src/main/resources/com/alipay/sofa/rpc/common/rpc-config-default.json
@@ -66,6 +66,8 @@ PS:大家也看到了，本JSON文档是支持注释的，而标准JSON是不支
   "default.transport": "netty4",
   // 默认tracer实现
   "default.tracer": "",
+  // 默认filter实现
+  "default.filters": [],
   /*-------------默认配置值结束-------------*/
 
 


### PR DESCRIPTION
support default filter config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added default filter settings for RPC configurations to enhance flexibility and customization.
  - Introduced `addFilter` method to easily append filters in configurations.

- **Tests**
  - Added test cases to verify the functionality of adding filters in `ConsumerConfig`.

- **Configuration**
  - Updated JSON configuration files to include default filter implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->