### PR TITLE
fix: set default 0 when get method timeout config

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/MethodConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/MethodConfig.java
@@ -137,7 +137,7 @@ public class MethodConfig implements Serializable {
      * @return the timeout
      */
     public Integer getTimeout() {
-        return timeout;
+        return timeout == null ? 0 : timeout;
     }
 
     /**

--- a/core/api/src/test/java/com/alipay/sofa/rpc/std/config/AbstractInterfaceConfigTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/std/config/AbstractInterfaceConfigTest.java
@@ -67,7 +67,6 @@ public class AbstractInterfaceConfigTest {
         }
     }
 
-
     @Test
     public void testDefaultValue() {
         TestConfig defaultConfig = new TestConfig();

--- a/core/api/src/test/java/com/alipay/sofa/rpc/std/config/AbstractInterfaceConfigTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/std/config/AbstractInterfaceConfigTest.java
@@ -23,6 +23,7 @@ import com.alipay.sofa.rpc.common.utils.TestUtils;
 import com.alipay.sofa.rpc.config.AbstractInterfaceConfig;
 import com.alipay.sofa.rpc.config.ApplicationConfig;
 import com.alipay.sofa.rpc.config.MethodConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
 import com.alipay.sofa.rpc.config.RegistryConfig;
 import com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException;
 import com.alipay.sofa.rpc.listener.ConfigListener;
@@ -50,6 +51,22 @@ import static org.junit.Assert.fail;
  * @version : AbstractInterfaceConfigTest.java, v 0.1 2022年01月25日 4:46 下午 zhaowang
  */
 public class AbstractInterfaceConfigTest {
+    @Test
+    public void testMethodTimeout() {
+        MethodConfig config = new MethodConfig();
+        config.setTimeout(null);
+
+        ProviderConfig p = new ProviderConfig();
+        p.setMethods(new HashMap<>());
+        p.getMethods().put("test", config);
+
+        try {
+            Assert.assertFalse(p.hasTimeout());
+        } catch (Exception e) {
+            Assert.fail("exception should not appears: " + e.getMessage());
+        }
+    }
+
 
     @Test
     public void testDefaultValue() {

--- a/registry/registry-sofa/src/test/java/com/alipay/sofa/rpc/registry/sofa/SofaRegistryHelperTest.java
+++ b/registry/registry-sofa/src/test/java/com/alipay/sofa/rpc/registry/sofa/SofaRegistryHelperTest.java
@@ -150,6 +150,17 @@ public class SofaRegistryHelperTest {
         Assert.assertEquals(serverConfig3.getPort(), providerInfo3.getPort());
         Assert.assertEquals(providerConfig.getAppName(), providerInfo3.getAttr(ProviderInfoAttrs.ATTR_APP_NAME));
         Assert.assertEquals(providerConfig.getTimeout(), providerInfo3.getDynamicAttr(ProviderInfoAttrs.ATTR_TIMEOUT));
+
+        ProviderConfig<?> providerConfig2 = new ProviderConfig<>();
+        providerConfig2.setMethods(new HashMap<>());
+        providerConfig2.getMethods().put("test", new MethodConfig().setTimeout(null));
+        Assert.assertNotNull(providerConfig2.getTimeout());
+        String s4 = SofaRegistryHelper.convertProviderToUrls(providerConfig2, serverConfig);
+        Assert.assertNotNull(s3);
+        ProviderInfo providerInfo4 = SofaRegistryHelper.parseProviderInfo(s4);
+        Assert.assertEquals(0, providerInfo4.getDynamicAttr(".test.timeout"));
+        Assert.assertFalse(providerConfig2.hasTimeout());
+
     }
 
     @Test


### PR DESCRIPTION
### Motivation:

The method-level `timeout` config is `Integer` type which accepts `null` value.

So if we add method config and set the method-level `timeout` to null, a `timeout=null` might be pub onto registry.

Say, `1.1.1.1:12200?rpcVer=12300&serialization=hessian&app_name=demo&[echo]=[clientTimeout#null]`.

When dealing with `null` value, some of the implementations may omit catching exception when doing `Integer.parseInt(null)`, leading to unexpected startup error.


### Modification:

As both `null` and `0` are meaningless in SOFARPC (might only indicate 'not set', but we do not care), I set `method.getTimeout` a default 0 return value if `null`.

### Result:
Focus on 
`com.alipay.sofa.rpc.registry.sofa.SofaRegistryHelper#convertProviderToUrls`
`com.alipay.sofa.rpc.registry.mesh.SofaRegistryHelper#convertProviderToUrls`
will not get and pub a `null` timeout value any more.
```
String key = "[" + methodName + "]";
String value = "[" + KEY_TIMEOUT + "#" + methodConfig.getTimeout() + "]";
sb.append(getKeyPairs(key, value))
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that the timeout configuration returns a default value of `0` when not set.

- **Tests**
	- Added new tests to verify timeout configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->