### PR TITLE
fix: remove wrong verify logic

### DIFF
--- a/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyBatchWriteQueueTest.java
+++ b/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyBatchWriteQueueTest.java
@@ -23,9 +23,7 @@ import io.netty.channel.EventLoop;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -37,20 +35,16 @@ import static org.mockito.Mockito.when;
  */
 public class NettyBatchWriteQueueTest {
 
-    @Mock
-    private Channel              mockChannel;
+    private Channel              mockChannel          = Mockito.mock(Channel.class);
 
-    @Mock
-    private EventLoop            mockEventLoop;
+    private EventLoop            mockEventLoop        = Mockito.mock(EventLoop.class);
 
-    @Mock
-    private ChannelPromise       mockChannelPromise;
+    private ChannelPromise       mockChannelPromise   = Mockito.mock(ChannelPromise.class);
 
-    private NettyBatchWriteQueue nettyBatchWriteQueue;
+    private NettyBatchWriteQueue nettyBatchWriteQueue = Mockito.mock(NettyBatchWriteQueue.class);
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
         when(mockChannel.newPromise()).thenReturn(mockChannelPromise);
         nettyBatchWriteQueue = NettyBatchWriteQueue.createWriteQueue(mockChannel);

--- a/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyChannelTest.java
+++ b/remoting/remoting-http/src/test/java/com/alipay/sofa/rpc/transport/netty/NettyChannelTest.java
@@ -16,7 +16,6 @@
  */
 package com.alipay.sofa.rpc.transport.netty;
 
-import com.alipay.sofa.rpc.common.utils.NetUtils;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -27,13 +26,9 @@ import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import java.net.InetSocketAddress;
-
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 /**
@@ -42,16 +37,12 @@ import static org.mockito.Mockito.when;
  */
 public class NettyChannelTest {
 
-    @Mock
     private Channel               mockChannel    = Mockito.mock(Channel.class);
 
-    @Mock
     private ChannelHandlerContext mockContext    = Mockito.mock(ChannelHandlerContext.class);
 
-    @Mock
     private NettyBatchWriteQueue  mockWriteQueue = Mockito.mock(NettyBatchWriteQueue.class);
 
-    @Mock
     private ChannelFuture         mockFuture     = Mockito.mock(ChannelFuture.class);
 
     private NettyChannel          nettyChannel;
@@ -62,6 +53,7 @@ public class NettyChannelTest {
         Mockito.when(mockChannel.alloc()).thenReturn(PooledByteBufAllocator.DEFAULT);
         when(mockContext.channel()).thenReturn(mockChannel);
         when(mockWriteQueue.enqueue(any())).thenReturn(mockFuture);
+
         nettyChannel = new NettyChannel(mockChannel);
         nettyChannel.setWriteQueue(mockWriteQueue);
     }
@@ -80,8 +72,8 @@ public class NettyChannelTest {
         listener.operationComplete((Future) mockFuture);
 
         // 验证没有错误日志被记录（因为操作是成功的）
-        Mockito.verify(Mockito.mock(NetUtils.class), times(10));
-        NetUtils.channelToString(any(InetSocketAddress.class), any(InetSocketAddress.class));
+        //        Mockito.verify(Mockito.mock(NetUtils.class), times(10));
+        //        NetUtils.channelToString(any(InetSocketAddress.class), any(InetSocketAddress.class));
     }
 
 }


### PR DESCRIPTION
### Motivation:

Fix wrong `Mockito.verify` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced test clarity and reduced boilerplate in the `NettyBatchWriteQueueTest` and `NettyChannelTest` by simplifying mock object initialization.
  - Adjusted focus in `NettyChannelTest` for improved test performance, while noting changes in verification logic. 



<!-- end of auto-generated comment: release notes by coderabbit.ai -->