### PR TITLE
use a tmp variable named [isOldProviderGroupEmpty] to resolve the bug…

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
@@ -209,14 +209,15 @@ public abstract class AbstractCluster extends Cluster {
     public void updateProviders(ProviderGroup providerGroup) {
         checkProviderInfo(providerGroup);
         ProviderGroup oldProviderGroup = addressHolder.getProviderGroup(providerGroup.getName());
+        boolean isOldProviderGroupEmpty = ProviderHelper.isEmpty(oldProviderGroup);
         if (ProviderHelper.isEmpty(providerGroup)) {
             addressHolder.updateProviders(providerGroup);
-            if (!ProviderHelper.isEmpty(oldProviderGroup)) {
+            if (!isOldProviderGroupEmpty) {
                 if (LOGGER.isWarnEnabled(consumerConfig.getAppName())) {
                     LOGGER.warnWithApp(consumerConfig.getAppName(), "Provider list is emptied, may be all " +
                         "providers has been closed, or this consumer has been add to blacklist");
-                    closeTransports();
                 }
+                closeTransports();
             }
         } else {
             addressHolder.updateProviders(providerGroup);


### PR DESCRIPTION
djust the location of method called  [closeTransports();] (#1442)

- https://github.com/sofastack/sofa-rpc/issues/1442

### Motivation:
there are two bugs in the AbstractCluster.java
1. variable named [oldProviderGroup] will be changed because of the method [addressHolder.updateProviders(providerGroup);], which will not execute method [ closeTransports();]

2. the method of [closeTransports();] should not be contain in the [LOGGER.isWarnEnabled(consumerConfig.getAppName())]


### Modification:
1. I use a boolean tmp named [isOldProviderGroupEmpty], avoid the change of [oldProviderGroup]
### Result:

Fixes #1442 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved code readability in the `updateProviders` method by reducing redundant checks.
	- Enhanced maintainability without altering functionality or control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->