### PR TITLE
fix SofaRpcMetricsCollector npe

### DIFF
--- a/metrics/metrics-prometheus/src/main/java/com/alipay/sofa/rpc/metrics/prometheus/SofaRpcMetricsCollector.java
+++ b/metrics/metrics-prometheus/src/main/java/com/alipay/sofa/rpc/metrics/prometheus/SofaRpcMetricsCollector.java
@@ -200,9 +200,9 @@ public class SofaRpcMetricsCollector extends Collector implements AutoCloseable 
         EventBus.unRegister(ConsumerSubEvent.class, subscriber);
     }
 
-    private static Long getLongAvoidNull(Object object) {
+    private static long getLongAvoidNull(Object object) {
         if (object == null) {
-            return null;
+            return 0L;
         }
 
         if (object instanceof Integer) {


### PR DESCRIPTION
### Motivation:

修复SofaRpcMetricsCollector中的npe问题

### Modification:
getLongAvoidNull方法取不到时返回0L，不返回null

### Result:

Fixes #1459. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the method for handling null values, ensuring a primitive long value is returned instead of null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->