### PR TITLE
fix method timeout resolve problem

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/ConsumerConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/ConsumerConfig.java
@@ -933,8 +933,11 @@ public class ConsumerConfig<T> extends AbstractInterfaceConfig<T, ConsumerConfig
      * @return the time out
      */
     public int getMethodTimeout(String methodName) {
-        return (Integer) getMethodConfigValue(methodName, RpcConstants.CONFIG_KEY_TIMEOUT,
-            getTimeout());
+        Object methodTimeout = getMethodConfigValue(methodName, RpcConstants.CONFIG_KEY_TIMEOUT);
+        if (methodTimeout == null || ((Integer) methodTimeout) == 0) {
+            return getTimeout();
+        }
+        return (Integer) methodTimeout;
     }
 
     /**

--- a/core/api/src/test/java/com/alipay/sofa/rpc/config/ConsumerConfigTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/config/ConsumerConfigTest.java
@@ -1,0 +1,41 @@
+package com.alipay.sofa.rpc.config;
+
+import com.alipay.sofa.rpc.invoke.Invoker;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Even
+ * @date 2025/3/4 21:36
+ */
+public class ConsumerConfigTest {
+
+    @Test
+    public void testMethodTimeout() {
+        ConsumerConfig<Invoker> consumerConfig = new ConsumerConfig<>();
+        consumerConfig.setTimeout(4000);
+        consumerConfig.setInterfaceId(Invoker.class.getName());
+        consumerConfig.getConfigValueCache(true);
+        Assert.assertEquals(4000, consumerConfig.getMethodTimeout("invoke"));
+
+        List<MethodConfig> methodConfigs = new ArrayList<>();
+        MethodConfig methodConfig = new MethodConfig();
+        methodConfig.setName("invoke");
+        methodConfigs.add(methodConfig);
+        consumerConfig.setMethods(methodConfigs);
+        consumerConfig.getConfigValueCache(true);
+        Assert.assertEquals(4000, consumerConfig.getMethodTimeout("invoke"));
+
+        methodConfig.setTimeout(5000);
+        consumerConfig.getConfigValueCache(true);
+        Assert.assertEquals(5000, consumerConfig.getMethodTimeout("invoke"));
+
+        methodConfig.setTimeout(-1);
+        consumerConfig.getConfigValueCache(true);
+        Assert.assertEquals(-1, consumerConfig.getMethodTimeout("invoke"));
+    }
+
+}


### PR DESCRIPTION
In accordance with issue https://github.com/sofastack/sofa-rpc/pull/1422, if the method's timeout value is set to the default value of 0, the getMethodTimeout method should return the interface's timeout value instead.