### PR TITLE
Fix exception status code mapping in FailFastCluster trace logging

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/FailFastCluster.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/FailFastCluster.java
@@ -52,6 +52,9 @@ public class FailFastCluster extends AbstractCluster {
                     "Failed to call " + request.getInterfaceName() + "." + request.getMethodName()
                         + " on remote server " + providerInfo + ", return null");
             }
+        } catch (SofaRpcException e) {
+            // 如果是SofaRpcException，直接抛出
+            throw e;
         } catch (Exception e) {
             throw new SofaRpcException(RpcErrorType.CLIENT_UNDECLARED_ERROR,
                 "Failed to call " + request.getInterfaceName() + "." + request.getMethodName()


### PR DESCRIPTION
### Motivation:

In FailFastCluster.doInvoke(), all exceptions (including SofaRpcException) were being wrapped as CLIENT_UNDECLARED_ERROR, causing incorrect status codes in trace logs:
Timeout exceptions should have status code 03 but were logged as 02
Other RPC exceptions lost their original error types

### Modification:

Added explicit handling for SofaRpcException to preserve original exception types



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure that specific exceptions are now correctly propagated without unnecessary wrapping. Users may notice more accurate error reporting in certain failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->