### PR TITLE
fix:Fix timeout response discard logic in BoltServerProcessor

### DIFF
--- a/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/server/bolt/BoltServerProcessor.java
+++ b/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/server/bolt/BoltServerProcessor.java
@@ -179,6 +179,8 @@ public class BoltServerProcessor extends AsyncUserProcessor<SofaRequest> {
                     response = doInvoke(serviceName, invoker, request);
                     if (bizCtx.isRequestTimeout()) { // 加上丢弃超时的响应的逻辑
                         throwable = clientTimeoutWhenSendResponse(appName, serviceName, bizCtx.getRemoteAddress());
+                        // response为空，代表超时应该丢弃响应
+                        response = null;
                         break invoke;
                     }
                 }


### PR DESCRIPTION
### Motivation:

response = doInvoke(serviceName, invoker, request);
if (bizCtx.isRequestTimeout()) {
throwable = clientTimeoutWhenSendResponse(appName, serviceName, bizCtx.getRemoteAddress());
break invoke; // response remains non-null
}

// Later logic: response is still sent when non-null
if (response != null) {
asyncCtx.sendResponse(response); // Bug: timeout response gets sent
}

### Modification:

Explicitly set response to null when timeout is detected to ensure no response is sent to timed-out clients.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timed-out requests to ensure that no response is sent back to the client after a timeout occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->