### PR TITLE
support custom triple header size & modify default max header size to 64 KB

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcOptions.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcOptions.java
@@ -416,6 +416,10 @@ public class RpcOptions {
      */
     public static final String TRANSPORT_BUFFER_SIZE                    = "transport.buffer.size";
     /**
+     * 默认 grpc maxInboundMetaSize大小
+     */
+    public static final String TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE = "transport.grpc.maxInboundMetadataSize";
+    /**
      * 默认 grpc maxInboundMessageSize大小
      */
     public static final String TRANSPORT_GRPC_MAX_INBOUND_MESSAGE_SIZE  = "transport.grpc.maxInboundMessageSize";

--- a/core/common/src/main/resources/com/alipay/sofa/rpc/common/rpc-config-default.json
+++ b/core/common/src/main/resources/com/alipay/sofa/rpc/common/rpc-config-default.json
@@ -234,6 +234,8 @@ PS:大家也看到了，本JSON文档是支持注释的，而标准JSON是不支
   "transport.use.epoll": false,
   //默认数据包大小 8*1024*1024
   "transport.payload.max": 8388608,
+  //默认grpc header 大小 64*1024
+  "transport.grpc.maxInboundMetadataSize": 65536,
   //默认grpc数据包大小 4*1024*1024
   "transport.grpc.maxInboundMessageSize": 4194304,
   // 客户端io线程数，默认 max(4,cpu+1)

--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/server/triple/TripleServer.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/server/triple/TripleServer.java
@@ -134,6 +134,7 @@ public class TripleServer implements Server {
             .workerEventLoopGroup(constructWorkerEventLoopGroup())
             .executor(bizThreadPool)
             .channelType(constructChannel())
+            .maxInboundMetadataSize(RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE))
             .maxInboundMessageSize(RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_MESSAGE_SIZE))
             .permitKeepAliveTime(1, TimeUnit.SECONDS)
             .permitKeepAliveWithoutCalls(true)

--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientTransport.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientTransport.java
@@ -283,6 +283,7 @@ public class TripleClientTransport extends ClientTransport {
         builder.usePlaintext();
         builder.disableRetry();
         builder.intercept(clientHeaderClientInterceptor);
+        builder.maxInboundMetadataSize(RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE));
         builder.maxInboundMessageSize(RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_MESSAGE_SIZE));
 
         if (KEEP_ALIVE_INTERVAL > 0) {

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/TripleServerTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/TripleServerTest.java
@@ -397,7 +397,7 @@ public class TripleServerTest {
         int originInboundMetadataSize = RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE);
         Assert.assertEquals(65536, originInboundMetadataSize);
         try {
-            ApplicationConfig applicationConfig = new ApplicationConfig().setAppName("triple-server1");
+            ApplicationConfig applicationConfig = new ApplicationConfig().setAppName("triple-defaultMetadata");
             int port = 50052;
             ServerConfig serverConfig = new ServerConfig()
                     .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)
@@ -444,7 +444,7 @@ public class TripleServerTest {
         Assert.assertEquals(65536, originInboundMetadataSize);
         RpcConfigs.putValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE, "67584");
         try {
-            ApplicationConfig applicationConfig = new ApplicationConfig().setAppName("triple-server1");
+            ApplicationConfig applicationConfig = new ApplicationConfig().setAppName("triple-customMetadata");
             int port = 50052;
             ServerConfig serverConfig = new ServerConfig()
                     .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/TripleServerTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/TripleServerTest.java
@@ -390,6 +390,101 @@ public class TripleServerTest {
         }
     }
 
+    @Test
+    public void testDefaultMetadataSize() {
+        boolean originDebugMode = RpcRunningState.isDebugMode();
+        RpcRunningState.setDebugMode(false);
+        int originInboundMetadataSize = RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE);
+        Assert.assertEquals(65536, originInboundMetadataSize);
+        try {
+            ApplicationConfig applicationConfig = new ApplicationConfig().setAppName("triple-server1");
+            int port = 50052;
+            ServerConfig serverConfig = new ServerConfig()
+                    .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)
+                    .setPort(port);
+            ProviderConfig<SampleService> providerConfig = new ProviderConfig<SampleService>()
+                    .setApplication(applicationConfig)
+                    .setBootstrap(RpcConstants.PROTOCOL_TYPE_TRIPLE)
+                    .setInterfaceId(SampleService.class.getName())
+                    .setRef(new SampleServiceImpl())
+                    .setServer(serverConfig);
+            providerConfig.export();
+
+            ConsumerConfig<SampleService> consumerConfig = new ConsumerConfig<>();
+            consumerConfig.setInterfaceId(SampleService.class.getName())
+                    .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)
+                    .setDirectUrl("tri://127.0.0.1:" + port);
+
+            SampleService sampleService = consumerConfig.refer();
+            String msg = buildMsg(1);
+            try {
+                RpcInvokeContext.getContext().addCustomHeader("grpc_custom_header", buildMsg(32));
+                sampleService.messageSize(msg, 5);
+                Assert.fail();
+            } catch (Exception e) {
+                Assert.assertTrue(e.getCause().getCause().getMessage().contains("Header size exceeded max allowed size (65536)"));
+            }
+
+            try {
+                RpcInvokeContext.getContext().addCustomHeader("grpc_custom_header", buildMsg(31));
+                sampleService.messageSize(msg, 1);
+            } catch (Exception e) {
+                Assert.fail();
+            }
+        } finally {
+            RpcRunningState.setDebugMode(originDebugMode);
+        }
+    }
+
+    @Test
+    public void testSetInboundMetadataSize() {
+        boolean originDebugMode = RpcRunningState.isDebugMode();
+        RpcRunningState.setDebugMode(false);
+        int originInboundMetadataSize = RpcConfigs.getIntValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE);
+        Assert.assertEquals(65536, originInboundMetadataSize);
+        RpcConfigs.putValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE, "67584");
+        try {
+            ApplicationConfig applicationConfig = new ApplicationConfig().setAppName("triple-server1");
+            int port = 50052;
+            ServerConfig serverConfig = new ServerConfig()
+                    .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)
+                    .setPort(port);
+            ProviderConfig<SampleService> providerConfig = new ProviderConfig<SampleService>()
+                    .setApplication(applicationConfig)
+                    .setBootstrap(RpcConstants.PROTOCOL_TYPE_TRIPLE)
+                    .setInterfaceId(SampleService.class.getName())
+                    .setRef(new SampleServiceImpl())
+                    .setServer(serverConfig);
+            providerConfig.export();
+
+            ConsumerConfig<SampleService> consumerConfig = new ConsumerConfig<>();
+            consumerConfig.setInterfaceId(SampleService.class.getName())
+                    .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)
+                    .setDirectUrl("tri://127.0.0.1:" + port);
+
+            SampleService sampleService = consumerConfig.refer();
+            String msg = buildMsg(1);
+            try {
+                RpcInvokeContext.getContext().addCustomHeader("grpc_custom_header", buildMsg(32));
+                sampleService.messageSize(msg, 5);
+            } catch (Exception e) {
+                Assert.fail();
+            }
+
+            try {
+                RpcInvokeContext.getContext().addCustomHeader("grpc_custom_header", buildMsg(33));
+                sampleService.messageSize(msg, 1);
+                Assert.fail();
+            } catch (Exception e) {
+                Assert.assertTrue(e.getCause().getCause().getMessage().contains("Header size exceeded max allowed size (67584)"));
+
+            }
+        } finally {
+            RpcRunningState.setDebugMode(originDebugMode);
+            RpcConfigs.putValue(RpcOptions.TRANSPORT_GRPC_MAX_INBOUND_METADATA_SIZE, originInboundMetadataSize);
+        }
+    }
+
     private String buildMsg(int messageSize) {
         StringBuilder sb = new StringBuilder();
         // 1KB


### PR DESCRIPTION
Support custom triple header size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable limit for gRPC inbound metadata (headers) on client and server.
  - Default maximum inbound metadata size set to 64KB (65536); adjustable via transport.grpc.maxInboundMetadataSize.

- **Bug Fixes**
  - Enforces inbound header size limits to prevent oversized-header failures and related crashes.

- **Tests**
  - Integration tests added to validate default and custom inbound metadata size behavior and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->