### PR TITLE
fix sharedChannel concurrent destroy problem

### DIFF
--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientTransport.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientTransport.java
@@ -119,9 +119,13 @@ public class TripleClientTransport extends ClientTransport {
             } catch (InterruptedException e) {
                 LOGGER.warn("Triple channel shut down interrupted.");
             }
-            channel = null;
+            if (channel.isShutdown()) {
+                channel = null;
+                channelMap.remove(providerInfo.toString());
+            }
+        } else {
+            channelMap.remove(providerInfo.toString());
         }
-        channelMap.remove(providerInfo.toString());
     }
 
     @Override

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/TripleGenericStreamTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/TripleGenericStreamTest.java
@@ -79,7 +79,6 @@ public class TripleGenericStreamTest {
             .setTimeout(1000000)
             .setDirectUrl("triple://127.0.0.1:50066?appName=triple-server");
         helloServiceRef = consumerConfig.refer();
-        Thread.sleep(5000);
     }
 
     @AfterClass

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/TripleStubStreamTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/TripleStubStreamTest.java
@@ -109,7 +109,6 @@ public class TripleStubStreamTest {
                 .setProtocol(RpcConstants.PROTOCOL_TYPE_TRIPLE)
                 .setDirectUrl("tri://127.0.0.1:" + 50051 + "?appName=triple-server");
         greeterStubToNative = consumerConfigToNative.refer();
-        Thread.sleep(10000);
     }
 
     @AfterClass


### PR DESCRIPTION
fix sharedChannel concurrent destroy problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client disconnect handling to avoid premature cleanup and ensure channels are only removed after confirmed shutdown, resulting in more reliable connection lifecycle and smoother shutdown behavior.
* **Tests**
  * Removed unnecessary delays in integration tests, significantly reducing test execution time and helping lower flakiness during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->