### PR TITLE
fix triple pojo overload issue

### DIFF
--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/utils/SofaProtoUtils.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/utils/SofaProtoUtils.java
@@ -101,7 +101,7 @@ public class SofaProtoUtils {
             String streamType = mapStreamType(method);
             if (StringUtils.isNotBlank(streamType)) {
                 if (methodCallType.putIfAbsent(method.getName(), streamType) != null) {
-                    throw new SofaRpcException(RpcErrorType.UNKNOWN, "triple pojo stream do not support method overload!!!");
+                    throw new SofaRpcException(RpcErrorType.CLIENT_CALL_TYPE, "Triple POJO streaming does not support method overload!!!");
                 }
             }
         }


### PR DESCRIPTION
fix triple pojo overload issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming endpoints now reject duplicate method names instead of silently overwriting previous definitions.
  * When streaming method overloads are detected, the system surfaces a clear error so misconfigured streaming APIs are discovered and fixed promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->