### PR TITLE
[AI-8th] fix: deduplicate methods in JavassistProxy to prevent DuplicateMemberException

### DIFF
--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -42,8 +42,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -154,12 +156,22 @@ public class JavassistProxy implements Proxy {
         Method[] methodAry = interfaceClass.getMethods();
         StringBuilder sb = new StringBuilder(512);
         int mi = 0;
+        // Track method signatures to skip duplicate methods from multiple parent interfaces.
+        // When an interface extends multiple parent interfaces that declare the same method,
+        // interfaceClass.getMethods() returns duplicates, causing Javassist to throw
+        // DuplicateMemberException when adding the same method twice.
+        // See: https://github.com/sofastack/sofa-rpc/issues/1384
+        Set<String> addedMethodSignatures = new HashSet<String>();
         for (Method m : methodAry) {
-            mi++;
             if (Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers()) ||
                 Modifier.isStatic(m.getModifiers())) {
                 continue;
             }
+            // Skip duplicate methods inherited from multiple parent interfaces
+            if (!addedMethodSignatures.add(buildMethodSignature(m))) {
+                continue;
+            }
+            mi++;
             Class<?>[] mType = m.getParameterTypes();
             Class<?> returnType = m.getReturnType();
 
@@ -283,6 +295,28 @@ public class JavassistProxy implements Proxy {
     @Override
     public Invoker getInvoker(Object proxyObject) {
         return parseInvoker(proxyObject);
+    }
+
+    /**
+     * Builds a unique method signature string in the format: methodName(paramType1,paramType2,...)
+     * Used to deduplicate methods inherited from multiple parent interfaces that declare the same method.
+     * Without deduplication, Javassist throws DuplicateMemberException when the same method is added twice.
+     *
+     * @param method the method to build a signature for
+     * @return the method signature string
+     */
+    private String buildMethodSignature(Method method) {
+        StringBuilder signature = new StringBuilder(method.getName());
+        signature.append('(');
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            if (i > 0) {
+                signature.append(',');
+            }
+            signature.append(parameterTypes[i].getName());
+        }
+        signature.append(')');
+        return signature.toString();
     }
 
     /**

--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -161,14 +161,14 @@ public class JavassistProxy implements Proxy {
         // interfaceClass.getMethods() returns duplicates, causing Javassist to throw
         // DuplicateMemberException when adding the same method twice.
         // See: https://github.com/sofastack/sofa-rpc/issues/1384
-        Set<String> addedMethodSignatures = new HashSet<String>();
+        Set<String> seenSignatures = new HashSet<>();
         for (Method m : methodAry) {
-            if (Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers()) ||
+            if (m.isBridge() || Modifier.isNative(m.getModifiers()) || Modifier.isFinal(m.getModifiers()) ||
                 Modifier.isStatic(m.getModifiers())) {
                 continue;
             }
             // Skip duplicate methods inherited from multiple parent interfaces
-            if (!addedMethodSignatures.add(buildMethodSignature(m))) {
+            if (!seenSignatures.add(buildMethodSignature(m))) {
                 continue;
             }
             mi++;
@@ -298,16 +298,20 @@ public class JavassistProxy implements Proxy {
     }
 
     /**
-     * Builds a unique method signature string in the format: methodName(paramType1,paramType2,...)
+     * Builds a unique method signature string in the format: returnType methodName(paramType1,paramType2,...)
      * Used to deduplicate methods inherited from multiple parent interfaces that declare the same method.
      * Without deduplication, Javassist throws DuplicateMemberException when the same method is added twice.
+     *
+     * <p>The return type is included to correctly handle covariant return types, where two methods
+     * may share the same name and parameter types but differ in return type (e.g. bridge methods).
      *
      * @param method the method to build a signature for
      * @return the method signature string
      */
     private String buildMethodSignature(Method method) {
-        StringBuilder signature = new StringBuilder(method.getName());
-        signature.append('(');
+        StringBuilder signature = new StringBuilder();
+        signature.append(method.getReturnType().getName()).append(' ');
+        signature.append(method.getName()).append('(');
         Class<?>[] parameterTypes = method.getParameterTypes();
         for (int i = 0; i < parameterTypes.length; i++) {
             if (i > 0) {

--- a/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/DiamondHelloService.java
+++ b/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/DiamondHelloService.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.proxy.javassist;
+
+/**
+ * Service interface that extends two parent interfaces declaring the same method (diamond inheritance).
+ * Used to verify that JavassistProxy correctly deduplicates inherited methods.
+ *
+ * @see <a href="https://github.com/sofastack/sofa-rpc/issues/1384">#1384</a>
+ */
+public interface DiamondHelloService extends DiamondSubInterface1, DiamondSubInterface2 {
+
+    String sayHello(String message);
+}

--- a/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/DiamondSubInterface1.java
+++ b/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/DiamondSubInterface1.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.proxy.javassist;
+
+/**
+ * Sub interface for diamond inheritance test.
+ * Declares getType() which is also declared in DiamondSubInterface2.
+ *
+ * @see <a href="https://github.com/sofastack/sofa-rpc/issues/1384">#1384</a>
+ */
+public interface DiamondSubInterface1 {
+
+    String getType();
+
+    String someMethod1();
+}

--- a/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/DiamondSubInterface2.java
+++ b/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/DiamondSubInterface2.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.proxy.javassist;
+
+/**
+ * Sub interface for diamond inheritance test.
+ * Declares getType() which is also declared in DiamondSubInterface1.
+ *
+ * @see <a href="https://github.com/sofastack/sofa-rpc/issues/1384">#1384</a>
+ */
+public interface DiamondSubInterface2 {
+
+    String getType();
+
+    String someMethod2();
+}

--- a/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxyTest.java
+++ b/core-impl/proxy/src/test/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxyTest.java
@@ -17,6 +17,8 @@
 package com.alipay.sofa.rpc.proxy.javassist;
 
 import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import com.alipay.sofa.rpc.invoke.Invoker;
 import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 import com.alipay.sofa.rpc.proxy.AbstractTestClass;
@@ -105,4 +107,30 @@ public class JavassistProxyTest {
         Assert.assertTrue(error);
     }
 
+    /**
+     * Tests that JavassistProxy correctly handles diamond interface inheritance
+     * where multiple parent interfaces declare the same method signature.
+     * Before the fix, this would throw DuplicateMemberException.
+     *
+     * @see <a href="https://github.com/sofastack/sofa-rpc/issues/1384">#1384</a>
+     */
+    @Test
+    public void testDiamondInheritanceProxy() {
+        JavassistProxy proxy = new JavassistProxy();
+
+        Invoker mockInvoker = request -> {
+            SofaResponse response = new SofaResponse();
+            response.setAppResponse("mock-" + request.getMethodName());
+            return response;
+        };
+
+        DiamondHelloService service = proxy.getProxy(DiamondHelloService.class, mockInvoker);
+        Assert.assertNotNull(service);
+
+        // Verify all methods from both sub-interfaces and the service itself are callable
+        Assert.assertEquals("mock-sayHello", service.sayHello("test"));
+        Assert.assertEquals("mock-getType", service.getType());
+        Assert.assertEquals("mock-someMethod1", service.someMethod1());
+        Assert.assertEquals("mock-someMethod2", service.someMethod2());
+    }
 }


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #1384

## Root Cause

When a service interface extends multiple parent interfaces that declare the same method signature (e.g. both `SubInterface1` and `SubInterface2` declare `String getType()`), `interfaceClass.getMethods()` returns duplicate `Method` objects — one for each parent interface.

`JavassistProxy.createMethod()` previously iterated over all returned methods without any deduplication, causing Javassist to call `mCtc.addMethod()` with the same method signature twice, which throws:

```
javassist.bytecode.DuplicateMemberException: duplicate method: getType in HelloService_proxy_0
```

Switching to ByteBuddy proxy worked as a workaround because ByteBuddy handles deduplication internally.

## Solution

Introduce `addedMethodSignatures` (`HashSet<String>`) in `createMethod()` to track method signatures in the format `methodName(paramType1,paramType2,...)`. Before processing each method, check if its signature has already been seen; if so, skip it. This ensures each unique method signature is only added once to the generated proxy class.

```java
Set<String> addedMethodSignatures = new HashSet<String>();
for (Method m : methodAry) {
    // ...
    if (!addedMethodSignatures.add(buildMethodSignature(m))) {
        continue; // skip duplicate method from multiple parent interfaces
    }
    mi++;
    // ... generate method body
}
```

## Reproduce

```java
public interface HelloService extends SubInterface1, SubInterface2 {
    String sayHello(String string);
}

interface SubInterface1 {
    String getType();   // same signature as SubInterface2.getType()
    String someMethod1();
}

interface SubInterface2 {
    String getType();   // duplicate!
    String someMethod2();
}
```

Before fix: throws `SofaRpcRuntimeException` wrapping `DuplicateMemberException`
After fix: proxy generated successfully

## Changes

- `core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java`
  - Added `import java.util.HashSet` and `import java.util.Set`
  - Added `addedMethodSignatures` set in `createMethod()` for deduplication
  - Added private method `buildMethodSignature(Method)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proxy generation failures that occurred when interfaces inherited identical methods from multiple parent interfaces, improving stability when working with complex interface hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->