### PR TITLE
[AI-8th] fix: respect virtual host and port in dubbo provider bootstrap

### DIFF
--- a/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrap.java
+++ b/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrap.java
@@ -203,8 +203,8 @@ public class DubboProviderBootstrap<T> extends ProviderBootstrap<T> {
                 List<String> urls = new ArrayList<String>();
                 for (ServerConfig server : servers) {
                     StringBuilder sb = new StringBuilder(200);
-                    sb.append(server.getProtocol()).append("://").append(server.getHost())
-                        .append(":").append(server.getPort()).append(server.getContextPath())
+                    sb.append(server.getProtocol()).append("://").append(resolveHost(server))
+                        .append(":").append(resolvePort(server)).append(server.getContextPath())
                         .append(providerConfig.getInterfaceId())
                         .append("?uniqueId=").append(providerConfig.getUniqueId())
                         .append(getKeyPairs("version", "1.0"))

--- a/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrap.java
+++ b/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrap.java
@@ -113,11 +113,11 @@ public class DubboProviderBootstrap<T> extends ProviderBootstrap<T> {
         }
     }
 
-    private void copyServerFields(ServerConfig serverConfig, ProtocolConfig protocolConfig) {
+    void copyServerFields(ServerConfig serverConfig, ProtocolConfig protocolConfig) {
         protocolConfig.setId(serverConfig.getId());
         protocolConfig.setName(serverConfig.getProtocol());
-        protocolConfig.setHost(serverConfig.getHost());
-        protocolConfig.setPort(serverConfig.getPort());
+        protocolConfig.setHost(resolveHost(serverConfig));
+        protocolConfig.setPort(resolvePort(serverConfig));
         protocolConfig.setAccepts(serverConfig.getAccepts());
         protocolConfig.setSerialization(serverConfig.getSerialization());
         if (!StringUtils.CONTEXT_SEP.equals(serverConfig.getContextPath())) {
@@ -130,6 +130,15 @@ public class DubboProviderBootstrap<T> extends ProviderBootstrap<T> {
         protocolConfig.setQueues(serverConfig.getQueues());
 
         protocolConfig.setParameters(serverConfig.getParameters());
+    }
+
+    private String resolveHost(ServerConfig serverConfig) {
+        return StringUtils.isNotBlank(serverConfig.getVirtualHost()) ? serverConfig.getVirtualHost()
+            : serverConfig.getHost();
+    }
+
+    private Integer resolvePort(ServerConfig serverConfig) {
+        return serverConfig.getVirtualPort() != null ? serverConfig.getVirtualPort() : serverConfig.getPort();
     }
 
     private void copyProvider(ProviderConfig<T> providerConfig, ServiceConfig<T> serviceConfig) {

--- a/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrap.java
+++ b/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrap.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.rpc.bootstrap.dubbo;
 
+import com.alipay.sofa.rpc.common.annotation.VisibleForTesting;
 import org.apache.dubbo.config.ProtocolConfig;
 import org.apache.dubbo.config.ServiceConfig;
 import com.alipay.sofa.rpc.bootstrap.ProviderBootstrap;
@@ -97,22 +98,28 @@ public class DubboProviderBootstrap<T> extends ProviderBootstrap<T> {
         if (CommonUtils.isNotEmpty(serverConfigs)) {
             List<ProtocolConfig> dubboProtocolConfigs = new ArrayList<ProtocolConfig>();
             for (ServerConfig serverConfig : serverConfigs) {
-                // 生成并丢到缓存里
-                ProtocolConfig protocolConfig = DubboSingleton.SERVER_MAP.get(serverConfig);
-                if (protocolConfig == null) {
-                    protocolConfig = new ProtocolConfig();
-                    copyServerFields(serverConfig, protocolConfig);
-                    ProtocolConfig old = DubboSingleton.SERVER_MAP.putIfAbsent(serverConfig, protocolConfig);
-                    if (old != null) {
-                        protocolConfig = old;
-                    }
-                }
+                ProtocolConfig protocolConfig = getOrCreateProtocolConfig(serverConfig);
                 dubboProtocolConfigs.add(protocolConfig);
             }
             serviceConfig.setProtocols(dubboProtocolConfigs);
         }
     }
 
+    ProtocolConfig getOrCreateProtocolConfig(ServerConfig serverConfig) {
+        String serverCacheKey = buildServerCacheKey(serverConfig);
+        ProtocolConfig protocolConfig = DubboSingleton.SERVER_MAP.get(serverCacheKey);
+        if (protocolConfig == null) {
+            protocolConfig = new ProtocolConfig();
+            copyServerFields(serverConfig, protocolConfig);
+            ProtocolConfig old = DubboSingleton.SERVER_MAP.putIfAbsent(serverCacheKey, protocolConfig);
+            if (old != null) {
+                protocolConfig = old;
+            }
+        }
+        return protocolConfig;
+    }
+
+    @VisibleForTesting
     void copyServerFields(ServerConfig serverConfig, ProtocolConfig protocolConfig) {
         protocolConfig.setId(serverConfig.getId());
         protocolConfig.setName(serverConfig.getProtocol());
@@ -139,6 +146,16 @@ public class DubboProviderBootstrap<T> extends ProviderBootstrap<T> {
 
     private Integer resolvePort(ServerConfig serverConfig) {
         return serverConfig.getVirtualPort() != null ? serverConfig.getVirtualPort() : serverConfig.getPort();
+    }
+
+    String buildServerCacheKey(ServerConfig serverConfig) {
+        StringBuilder sb = new StringBuilder(64);
+        sb.append(serverConfig.getProtocol()).append(':')
+            .append(serverConfig.getHost()).append(':')
+            .append(serverConfig.getPort()).append(':')
+            .append(resolveHost(serverConfig)).append(':')
+            .append(resolvePort(serverConfig));
+        return sb.toString();
     }
 
     private void copyProvider(ProviderConfig<T> providerConfig, ServiceConfig<T> serviceConfig) {

--- a/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboSingleton.java
+++ b/bootstrap/bootstrap-dubbo/src/main/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboSingleton.java
@@ -19,7 +19,6 @@ package com.alipay.sofa.rpc.bootstrap.dubbo;
 import org.apache.dubbo.config.ProtocolConfig;
 import com.alipay.sofa.rpc.base.Destroyable;
 import com.alipay.sofa.rpc.config.RegistryConfig;
-import com.alipay.sofa.rpc.config.ServerConfig;
 import com.alipay.sofa.rpc.context.RpcRuntimeContext;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
@@ -48,9 +47,9 @@ public class DubboSingleton {
     }
 
     /**
-     * sofa.SeverConfig --> dubbo.ProtocolConfig
+     * server cache key --> dubbo.ProtocolConfig
      */
-    final static ConcurrentMap<ServerConfig, ProtocolConfig>                           SERVER_MAP   = new ConcurrentHashMap<>();
+    final static ConcurrentMap<String, ProtocolConfig>                                 SERVER_MAP   = new ConcurrentHashMap<>();
 
     /**
      * sofa.RegistryConfig --> dubbo.RegistryConfig

--- a/bootstrap/bootstrap-dubbo/src/test/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrapTest.java
+++ b/bootstrap/bootstrap-dubbo/src/test/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrapTest.java
@@ -143,4 +143,24 @@ public class DubboProviderBootstrapTest {
         Assert.assertEquals("127.0.0.1", protocolConfig.getHost());
         Assert.assertEquals(Integer.valueOf(80), protocolConfig.getPort());
     }
+
+    /**
+     * buildUrls should use the resolved virtual address instead of the bound host and port.
+     */
+    @Test
+    public void test_build_urls_use_virtual_host_and_port() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setContextPath("/")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.1")
+            .setVirtualPort(80);
+        dubboProviderBootstrap.getProviderConfig().setServer(serverConfig);
+        dubboProviderBootstrap.exported = true;
+
+        String url = dubboProviderBootstrap.buildUrls().get(0).toString();
+        Assert.assertTrue(url.startsWith("dubbo://10.0.0.1:80/" + DemoService.class.getName()));
+        Assert.assertTrue(url.contains("?uniqueId="));
+    }
 }

--- a/bootstrap/bootstrap-dubbo/src/test/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrapTest.java
+++ b/bootstrap/bootstrap-dubbo/src/test/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrapTest.java
@@ -35,6 +35,7 @@ public class DubboProviderBootstrapTest {
 
     @Before
     public void setUp() throws Exception {
+        DubboSingleton.SERVER_MAP.clear();
 
         ApplicationConfig serverApplacation = new ApplicationConfig();
         serverApplacation.setAppName("server");
@@ -162,5 +163,78 @@ public class DubboProviderBootstrapTest {
         String url = dubboProviderBootstrap.buildUrls().get(0).toString();
         Assert.assertTrue(url.startsWith("dubbo://10.0.0.1:80/" + DemoService.class.getName()));
         Assert.assertTrue(url.contains("?uniqueId="));
+    }
+
+    /**
+     * buildUrls should fall back to the bound host and port when no virtual address is configured.
+     */
+    @Test
+    public void test_build_urls_fallback_to_host_and_port() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setContextPath("/")
+            .setHost("127.0.0.1")
+            .setPort(12200);
+        dubboProviderBootstrap.getProviderConfig().setServer(serverConfig);
+        dubboProviderBootstrap.exported = true;
+
+        String url = dubboProviderBootstrap.buildUrls().get(0).toString();
+        Assert.assertTrue(url.startsWith("dubbo://127.0.0.1:12200/" + DemoService.class.getName()));
+        Assert.assertTrue(url.contains("?uniqueId="));
+    }
+
+    /**
+     * Different virtual addresses should not reuse the same cached ProtocolConfig for the same bound address.
+     */
+    @Test
+    public void test_protocol_config_cache_key_should_distinguish_virtual_address() {
+        ServerConfig serverConfig1 = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.1")
+            .setVirtualPort(80);
+        ServerConfig serverConfig2 = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.2")
+            .setVirtualPort(81);
+
+        ProtocolConfig protocolConfig1 = dubboProviderBootstrap.getOrCreateProtocolConfig(serverConfig1);
+        ProtocolConfig protocolConfig2 = dubboProviderBootstrap.getOrCreateProtocolConfig(serverConfig2);
+
+        Assert.assertNotSame(protocolConfig1, protocolConfig2);
+        Assert.assertEquals("10.0.0.1", protocolConfig1.getHost());
+        Assert.assertEquals(Integer.valueOf(80), protocolConfig1.getPort());
+        Assert.assertEquals("10.0.0.2", protocolConfig2.getHost());
+        Assert.assertEquals(Integer.valueOf(81), protocolConfig2.getPort());
+    }
+
+    /**
+     * Same resolved virtual address should reuse the cached ProtocolConfig even if different ServerConfig instances
+     * share the same bound address.
+     */
+    @Test
+    public void test_protocol_config_cache_key_should_reuse_same_virtual_address() {
+        ServerConfig serverConfig1 = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.1")
+            .setVirtualPort(80);
+        ServerConfig serverConfig2 = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.1")
+            .setVirtualPort(80);
+
+        ProtocolConfig protocolConfig1 = dubboProviderBootstrap.getOrCreateProtocolConfig(serverConfig1);
+        ProtocolConfig protocolConfig2 = dubboProviderBootstrap.getOrCreateProtocolConfig(serverConfig2);
+
+        Assert.assertSame(protocolConfig1, protocolConfig2);
+        Assert.assertEquals("10.0.0.1", protocolConfig1.getHost());
+        Assert.assertEquals(Integer.valueOf(80), protocolConfig1.getPort());
     }
 }

--- a/bootstrap/bootstrap-dubbo/src/test/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrapTest.java
+++ b/bootstrap/bootstrap-dubbo/src/test/java/com/alipay/sofa/rpc/bootstrap/dubbo/DubboProviderBootstrapTest.java
@@ -20,6 +20,8 @@ import com.alipay.sofa.rpc.bootstrap.dubbo.demo.DemoService;
 import com.alipay.sofa.rpc.bootstrap.dubbo.demo.DemoServiceImpl;
 import com.alipay.sofa.rpc.config.ApplicationConfig;
 import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import org.apache.dubbo.config.ProtocolConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,5 +51,96 @@ public class DubboProviderBootstrapTest {
     @Test
     public void test_dubbo_service_version() {
         Assert.assertEquals("1.0.1", dubboProviderBootstrap.getProviderConfig().getParameter("version"));
+    }
+
+    /**
+     * virtualHost and virtualPort should override the bound host and port together.
+     */
+    @Test
+    public void test_copy_server_fields_use_virtual_host_and_port() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.1")
+            .setVirtualPort(80);
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+
+        dubboProviderBootstrap.copyServerFields(serverConfig, protocolConfig);
+
+        Assert.assertEquals("10.0.0.1", protocolConfig.getHost());
+        Assert.assertEquals(Integer.valueOf(80), protocolConfig.getPort());
+    }
+
+    /**
+     * Fall back to the original host and port when no virtual address is configured.
+     */
+    @Test
+    public void test_copy_server_fields_fallback_to_host_and_port() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("127.0.0.1")
+            .setPort(12200);
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+
+        dubboProviderBootstrap.copyServerFields(serverConfig, protocolConfig);
+
+        Assert.assertEquals("127.0.0.1", protocolConfig.getHost());
+        Assert.assertEquals(Integer.valueOf(12200), protocolConfig.getPort());
+    }
+
+    /**
+     * Blank virtualHost should be treated as unset, while virtualPort still takes effect.
+     */
+    @Test
+    public void test_copy_server_fields_fallback_to_host_when_virtual_host_is_blank() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("127.0.0.1")
+            .setPort(12200)
+            .setVirtualHost("   ")
+            .setVirtualPort(80);
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+
+        dubboProviderBootstrap.copyServerFields(serverConfig, protocolConfig);
+
+        Assert.assertEquals("127.0.0.1", protocolConfig.getHost());
+        Assert.assertEquals(Integer.valueOf(80), protocolConfig.getPort());
+    }
+
+    /**
+     * If only virtualHost is configured, the original port should still be used.
+     */
+    @Test
+    public void test_copy_server_fields_use_virtual_host_and_origin_port_when_virtual_port_is_null() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("0.0.0.0")
+            .setPort(12200)
+            .setVirtualHost("10.0.0.1");
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+
+        dubboProviderBootstrap.copyServerFields(serverConfig, protocolConfig);
+
+        Assert.assertEquals("10.0.0.1", protocolConfig.getHost());
+        Assert.assertEquals(Integer.valueOf(12200), protocolConfig.getPort());
+    }
+
+    /**
+     * If only virtualPort is configured, the original host should still be used.
+     */
+    @Test
+    public void test_copy_server_fields_use_origin_host_and_virtual_port_when_virtual_host_is_null() throws Exception {
+        ServerConfig serverConfig = new ServerConfig()
+            .setProtocol("dubbo")
+            .setHost("127.0.0.1")
+            .setPort(12200)
+            .setVirtualPort(80);
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+
+        dubboProviderBootstrap.copyServerFields(serverConfig, protocolConfig);
+
+        Assert.assertEquals("127.0.0.1", protocolConfig.getHost());
+        Assert.assertEquals(Integer.valueOf(80), protocolConfig.getPort());
     }
 }


### PR DESCRIPTION
### Motivation:

  `DubboProviderBootstrap.copyServerFields()` only copied `host` and `port`, and ignored `virtualHost` / `virtualPort` from `ServerConfig`.

  This causes the Dubbo provider to publish or register the bound address instead of the expected virtual address in NAT, container, load balancer, or port-mapping scenarios.

  Fixes #1119.

  ### Modification:

  - update `DubboProviderBootstrap.copyServerFields()` to prefer `virtualHost` over `host`
  - update `DubboProviderBootstrap.copyServerFields()` to prefer `virtualPort` over `port`
  - keep fallback behavior when `virtualHost` is blank or `virtualPort` is null
  - add unit tests for:
    - virtual host and virtual port both configured
    - no virtual address configured
    - blank virtual host with virtual port configured
    - only virtual host configured
    - only virtual port configured

  ### Result:

  Fixes #1119.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dubbo provider bootstrap now respects virtual host/port settings, falls back to bound host/port when needed, and uses the resolved address when generating service endpoints. Caching was improved to correctly distinguish different virtual/bound address combinations.

* **Tests**
  * Added tests covering virtual host/port combinations, fallback rules, URL generation (including uniqueId) and cache reuse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->