### PR TITLE
[AI-8th] Support Configurable Retry Exceptions

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/FailoverCluster.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/FailoverCluster.java
@@ -58,8 +58,11 @@ public class FailoverCluster extends AbstractCluster {
         String methodName = request.getMethodName();
         int retries = consumerConfig.getMethodRetries(methodName);
         int time = 0;
+        List<Class<? extends Throwable>> retryableExceptions = RetryableExceptionHelper
+            .resolveRetryExceptions(consumerConfig.getMethodRetryExceptions(methodName));
         // 异常日志
         SofaRpcException throwable = null;
+        SofaResponse exceptionResponse = null;
         List<ProviderInfo> invokedProviderInfos = new ArrayList<ProviderInfo>(retries + 1);
         do {
             ProviderInfo providerInfo = null;
@@ -67,39 +70,60 @@ public class FailoverCluster extends AbstractCluster {
                 providerInfo = select(request, invokedProviderInfos);
                 SofaResponse response = filterChain(providerInfo, request);
                 if (response != null) {
-                    if (throwable != null) {
-                        if (LOGGER.isWarnEnabled(consumerConfig.getAppName())) {
-                            LOGGER.warnWithApp(consumerConfig.getAppName(),
-                                LogCodes.getLog(LogCodes.WARN_SUCCESS_BY_RETRY,
-                                    throwable.getClass() + ":" + throwable.getMessage(),
-                                    invokedProviderInfos));
+                    if (RetryableExceptionHelper.shouldRetry(response, retryableExceptions)) {
+                        exceptionResponse = response;
+                        throwable = null;
+                        time++;
+                    } else {
+                        if (throwable != null || exceptionResponse != null) {
+                            String failureMessage = RetryableExceptionHelper.buildFailureMessage(throwable,
+                                exceptionResponse);
+                            if (LOGGER.isWarnEnabled(consumerConfig.getAppName())) {
+                                LOGGER.warnWithApp(consumerConfig.getAppName(),
+                                    LogCodes.getLog(LogCodes.WARN_SUCCESS_BY_RETRY, failureMessage,
+                                        invokedProviderInfos));
+                            }
                         }
+                        return response;
                     }
-                    return response;
                 } else {
+                    exceptionResponse = null;
                     throwable = new SofaRpcException(RpcErrorType.CLIENT_UNDECLARED_ERROR,
                         "Failed to call " + request.getInterfaceName() + "." + methodName
                             + " on remote server " + providerInfo + ", return null");
                     time++;
                 }
-            } catch (SofaRpcException e) { // 服务端异常+ 超时异常 才发起rpc异常重试
-                if (e.getErrorType() == RpcErrorType.SERVER_BUSY
-                    || e.getErrorType() == RpcErrorType.CLIENT_TIMEOUT) {
+            } catch (SofaRpcException e) {
+                if (RetryableExceptionHelper.shouldRetry(e, retryableExceptions)) {
+                    exceptionResponse = null;
                     throwable = e;
                     time++;
                 } else {
                     // throw the exception that caused the retry
                     if (throwable != null) {
                         throw throwable;
+                    } else if (exceptionResponse != null) {
+                        return exceptionResponse;
                     } else {
                         throw e;
                     }
                 }
-            } catch (Exception e) { // 其它异常不重试
-                throw new SofaRpcException(RpcErrorType.CLIENT_UNDECLARED_ERROR,
+            } catch (Exception e) {
+                SofaRpcException wrappedException = new SofaRpcException(RpcErrorType.CLIENT_UNDECLARED_ERROR,
                     "Failed to call " + request.getInterfaceName() + "." + request.getMethodName()
                         + " on remote server: " + providerInfo + ", cause by unknown exception: "
                         + e.getClass().getName() + ", message is: " + e.getMessage(), e);
+                if (RetryableExceptionHelper.shouldRetry(e, retryableExceptions)) {
+                    exceptionResponse = null;
+                    throwable = wrappedException;
+                    time++;
+                } else if (throwable != null) {
+                    throw throwable;
+                } else if (exceptionResponse != null) {
+                    return exceptionResponse;
+                } else {
+                    throw wrappedException;
+                }
             } finally {
                 if (RpcInternalContext.isAttachmentEnable()) {
                     RpcInternalContext.getContext().setAttachment(RpcConstants.INTERNAL_KEY_INVOKE_TIMES,
@@ -111,6 +135,9 @@ public class FailoverCluster extends AbstractCluster {
             }
         } while (time <= retries);
 
+        if (exceptionResponse != null) {
+            return exceptionResponse;
+        }
         throw throwable;
     }
 

--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/RetryableExceptionHelper.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/RetryableExceptionHelper.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.client;
+
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.common.utils.ClassUtils;
+import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.core.exception.RpcErrorType;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+final class RetryableExceptionHelper {
+
+    private RetryableExceptionHelper() {
+    }
+
+    static boolean shouldRetry(SofaRpcException exception, List<Class<? extends Throwable>> retryableExceptions) {
+        return isDefaultRetryable(exception) || matches(exception, retryableExceptions);
+    }
+
+    static boolean shouldRetry(Throwable throwable, List<Class<? extends Throwable>> retryableExceptions) {
+        return matches(throwable, retryableExceptions);
+    }
+
+    static boolean shouldRetry(SofaResponse response, List<Class<? extends Throwable>> retryableExceptions) {
+        return matches(getResponseThrowable(response), retryableExceptions)
+            || matchesRemoteException(response, retryableExceptions);
+    }
+
+    static Throwable getResponseThrowable(SofaResponse response) {
+        if (response == null) {
+            return null;
+        }
+        Object appResponse = response.getAppResponse();
+        return appResponse instanceof Throwable ? (Throwable) appResponse : null;
+    }
+
+    static List<Class<? extends Throwable>> resolveRetryExceptions(String retryExceptions) {
+        if (StringUtils.isBlank(retryExceptions)) {
+            return Collections.emptyList();
+        }
+        String[] classNames = StringUtils.splitWithCommaOrSemicolon(retryExceptions);
+        List<Class<? extends Throwable>> result = new ArrayList<Class<? extends Throwable>>(classNames.length);
+        for (String className : classNames) {
+            Class<?> exceptionClass;
+            try {
+                exceptionClass = ClassUtils.forName(className);
+            } catch (RuntimeException e) {
+                throw new IllegalArgumentException("Failed to load retry exception class: " + className, e);
+            }
+            if (!Throwable.class.isAssignableFrom(exceptionClass)) {
+                throw new IllegalArgumentException("Retry exception class must extend Throwable: " + className);
+            }
+            result.add(castThrowableClass(exceptionClass));
+        }
+        return result;
+    }
+
+    static String buildFailureMessage(SofaRpcException exception, SofaResponse response) {
+        Throwable failure = exception != null ? exception : getResponseThrowable(response);
+        if (failure == null) {
+            return null;
+        }
+        return failure.getClass() + ":" + failure.getMessage();
+    }
+
+    private static boolean isDefaultRetryable(SofaRpcException exception) {
+        return exception != null && (exception.getErrorType() == RpcErrorType.SERVER_BUSY
+            || exception.getErrorType() == RpcErrorType.CLIENT_TIMEOUT);
+    }
+
+    private static boolean matches(Throwable throwable, List<Class<? extends Throwable>> retryableExceptions) {
+        if (throwable == null || retryableExceptions.isEmpty()) {
+            return false;
+        }
+        Throwable current = throwable;
+        while (current != null) {
+            for (Class<? extends Throwable> retryableException : retryableExceptions) {
+                if (retryableException.isAssignableFrom(current.getClass())) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean matchesRemoteException(SofaResponse response,
+                                                  List<Class<? extends Throwable>> retryableExceptions) {
+        if (response == null || retryableExceptions.isEmpty()) {
+            return false;
+        }
+        Object exceptionClassName = response.getResponseProp(RemotingConstants.HEAD_RESPONSE_EXCEPTION);
+        if (!(exceptionClassName instanceof String) || StringUtils.isBlank((String) exceptionClassName)) {
+            return false;
+        }
+        Class<?> exceptionClass;
+        try {
+            exceptionClass = ClassUtils.forName((String) exceptionClassName);
+        } catch (RuntimeException e) {
+            return matchesClassName((String) exceptionClassName, retryableExceptions);
+        }
+        if (!Throwable.class.isAssignableFrom(exceptionClass)) {
+            return false;
+        }
+        for (Class<? extends Throwable> retryableException : retryableExceptions) {
+            if (retryableException.isAssignableFrom(exceptionClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesClassName(String exceptionClassName,
+                                            List<Class<? extends Throwable>> retryableExceptions) {
+        for (Class<? extends Throwable> retryableException : retryableExceptions) {
+            if (retryableException.getName().equals(exceptionClassName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Throwable> castThrowableClass(Class<?> exceptionClass) {
+        return (Class<? extends Throwable>) exceptionClass;
+    }
+}

--- a/core-impl/client/src/test/java/com/alipay/sofa/rpc/client/FailoverClusterTest.java
+++ b/core-impl/client/src/test/java/com/alipay/sofa/rpc/client/FailoverClusterTest.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.client;
+
+import com.alipay.sofa.rpc.bootstrap.ConsumerBootstrap;
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.config.ApplicationConfig;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.MethodConfig;
+import com.alipay.sofa.rpc.core.exception.RpcErrorType;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+public class FailoverClusterTest {
+
+    @Test
+    public void testRetryCustomResponseException() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(CustomRetryException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            response(new CustomRetryException("retry once")), response("success"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertEquals("success", response.getAppResponse());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testRetryRemoteResponseExceptionClass() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(CustomRetryException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            remoteExceptionResponse(CustomRetryException.class), response("success"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertEquals("success", response.getAppResponse());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testReturnLastResponseWhenCustomResponseExceptionExhausted() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(CustomRetryException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            response(new CustomRetryException("retry-1")), response(new CustomRetryException("retry-2")));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertTrue(response.getAppResponse() instanceof CustomRetryException);
+        Assert.assertEquals("retry-2", ((CustomRetryException) response.getAppResponse()).getMessage());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testRetryConfiguredThrownException() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(IllegalStateException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig, new IllegalStateException("retry me"),
+            response("success"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertEquals("success", response.getAppResponse());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testBuiltinRetryableSofaRpcExceptionStillWorks() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            new SofaRpcException(RpcErrorType.CLIENT_TIMEOUT, "timeout"), response("success"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertEquals("success", response.getAppResponse());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testMethodRetryExceptionOverride() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(IllegalStateException.class.getName());
+        MethodConfig methodConfig = new MethodConfig().setName("sayHello")
+            .setRetryExceptions(IllegalArgumentException.class.getName());
+        consumerConfig.setMethods(Arrays.asList(methodConfig));
+        consumerConfig.getConfigValueCache(true);
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig, new IllegalArgumentException("retry"),
+            response("success"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertEquals("success", response.getAppResponse());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testThrowOriginalRetryCauseWhenLaterFailureIsNotRetryable() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            new SofaRpcException(RpcErrorType.CLIENT_TIMEOUT, "timeout"),
+            new SofaRpcException(RpcErrorType.CLIENT_UNDECLARED_ERROR, "fatal"));
+
+        try {
+            cluster.doInvoke(createRequest());
+            Assert.fail("should throw the retry cause");
+        } catch (SofaRpcException e) {
+            Assert.assertEquals(RpcErrorType.CLIENT_TIMEOUT, e.getErrorType());
+        }
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testReturnRetryableResponseWhenLaterRpcExceptionIsNotRetryable() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(CustomRetryException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            response(new CustomRetryException("retry-response")),
+            new SofaRpcException(RpcErrorType.CLIENT_UNDECLARED_ERROR, "fatal"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertTrue(response.getAppResponse() instanceof CustomRetryException);
+        Assert.assertEquals("retry-response", ((CustomRetryException) response.getAppResponse()).getMessage());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testThrowRetryableWrappedExceptionWhenLaterExceptionIsNotRetryable() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(IllegalStateException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig, new IllegalStateException("retry"),
+            new IllegalArgumentException("fatal"));
+
+        try {
+            cluster.doInvoke(createRequest());
+            Assert.fail("should throw wrapped retryable exception");
+        } catch (SofaRpcException e) {
+            Assert.assertTrue(e.getCause() instanceof IllegalStateException);
+            Assert.assertEquals("retry", e.getCause().getMessage());
+        }
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testReturnRetryableResponseWhenLaterExceptionIsNotRetryable() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(CustomRetryException.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig,
+            response(new CustomRetryException("retry-response")), new IllegalArgumentException("fatal"));
+
+        SofaResponse response = cluster.doInvoke(createRequest());
+
+        Assert.assertTrue(response.getAppResponse() instanceof CustomRetryException);
+        Assert.assertEquals("retry-response", ((CustomRetryException) response.getAppResponse()).getMessage());
+        Assert.assertEquals(2, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testThrowWrappedExceptionWhenExceptionIsNotRetryable() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(0);
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig, new IllegalArgumentException("fatal"));
+
+        try {
+            cluster.doInvoke(createRequest());
+            Assert.fail("should throw wrapped exception");
+        } catch (SofaRpcException e) {
+            Assert.assertTrue(e.getCause() instanceof IllegalArgumentException);
+            Assert.assertEquals("fatal", e.getCause().getMessage());
+        }
+        Assert.assertEquals(1, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testThrowUndeclaredExceptionWhenResponseIsNull() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(0);
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig, (Object) null);
+
+        try {
+            cluster.doInvoke(createRequest());
+            Assert.fail("should throw undeclared exception");
+        } catch (SofaRpcException e) {
+            Assert.assertEquals(RpcErrorType.CLIENT_UNDECLARED_ERROR, e.getErrorType());
+            Assert.assertTrue(e.getMessage().contains("return null"));
+        }
+        Assert.assertEquals(1, cluster.getInvokeTimes());
+    }
+
+    @Test
+    public void testInvalidRetryExceptionConfigFailsFast() {
+        ConsumerConfig<Object> consumerConfig = createConsumerConfig();
+        consumerConfig.setRetries(1);
+        consumerConfig.setRetryExceptions(String.class.getName());
+
+        TestFailoverCluster cluster = new TestFailoverCluster(consumerConfig, response("ignored"));
+
+        try {
+            cluster.doInvoke(createRequest());
+            Assert.fail("should reject invalid retry exception configuration");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("Retry exception class must extend Throwable"));
+        }
+        Assert.assertEquals(0, cluster.getInvokeTimes());
+    }
+
+    private static ConsumerConfig<Object> createConsumerConfig() {
+        return new ConsumerConfig<Object>().setProtocol("test")
+            .setBootstrap("test")
+            .setApplication(new ApplicationConfig().setAppName("retry-test"))
+            .setInterfaceId(TestService.class.getName());
+    }
+
+    private static SofaRequest createRequest() {
+        SofaRequest request = new SofaRequest();
+        request.setInterfaceName(TestService.class.getName());
+        request.setMethodName("sayHello");
+        return request;
+    }
+
+    private static SofaResponse response(Object appResponse) {
+        SofaResponse response = new SofaResponse();
+        response.setAppResponse(appResponse);
+        return response;
+    }
+
+    private static SofaResponse remoteExceptionResponse(Class<? extends Throwable> exceptionClass) {
+        SofaResponse response = response(new SofaRpcException(RpcErrorType.SERVER_BIZ, "remote error"));
+        response.addResponseProp(RemotingConstants.HEAD_RESPONSE_EXCEPTION, exceptionClass.getName());
+        return response;
+    }
+
+    public interface TestService {
+        String sayHello();
+    }
+
+    public static class CustomRetryException extends RuntimeException {
+        public CustomRetryException(String message) {
+            super(message);
+        }
+    }
+
+    private static class TestFailoverCluster extends FailoverCluster {
+        private final Deque<Object> results;
+        private int                 invokeTimes;
+
+        TestFailoverCluster(ConsumerConfig<Object> consumerConfig, Object... results) {
+            super(new ConsumerBootstrap<Object>(consumerConfig) {
+                @Override
+                public Object refer() {
+                    return null;
+                }
+
+                @Override
+                public void unRefer() {
+                }
+
+                @Override
+                public Object getProxyIns() {
+                    return null;
+                }
+
+                @Override
+                public Cluster getCluster() {
+                    return null;
+                }
+
+                @Override
+                public List<ProviderGroup> subscribe() {
+                    return null;
+                }
+
+                @Override
+                public boolean isSubscribed() {
+                    return false;
+                }
+            });
+            this.results = new LinkedList<Object>(Arrays.asList(results));
+        }
+
+        @Override
+        protected ProviderInfo select(SofaRequest message, List<ProviderInfo> invokedProviderInfos) {
+            ProviderInfo providerInfo = new ProviderInfo();
+            providerInfo.setHost("127.0.0.1");
+            providerInfo.setPort(12200 + invokeTimes);
+            return providerInfo;
+        }
+
+        @Override
+        protected SofaResponse filterChain(ProviderInfo providerInfo, SofaRequest request) {
+            invokeTimes++;
+            Object result = results.removeFirst();
+            if (result instanceof SofaRpcException) {
+                throw (SofaRpcException) result;
+            } else if (result instanceof RuntimeException) {
+                throw (RuntimeException) result;
+            }
+            return (SofaResponse) result;
+        }
+
+        int getInvokeTimes() {
+            return invokeTimes;
+        }
+    }
+}

--- a/core-impl/client/src/test/java/com/alipay/sofa/rpc/client/RetryableExceptionHelperTest.java
+++ b/core-impl/client/src/test/java/com/alipay/sofa/rpc/client/RetryableExceptionHelperTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.client;
+
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.core.exception.RpcErrorType;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RetryableExceptionHelperTest {
+
+    @Test
+    public void testShouldRetryDefaultSofaRpcException() {
+        Assert.assertTrue(RetryableExceptionHelper.shouldRetry(new SofaRpcException(RpcErrorType.SERVER_BUSY, "busy"),
+            RetryableExceptionHelper.resolveRetryExceptions(null)));
+        Assert.assertTrue(RetryableExceptionHelper.shouldRetry(new SofaRpcException(RpcErrorType.CLIENT_TIMEOUT,
+            "timeout"), RetryableExceptionHelper.resolveRetryExceptions(null)));
+        Assert.assertFalse(RetryableExceptionHelper.shouldRetry(new SofaRpcException(
+            RpcErrorType.CLIENT_UNDECLARED_ERROR, "fatal"), RetryableExceptionHelper.resolveRetryExceptions(null)));
+    }
+
+    @Test
+    public void testResolveRetryExceptionsAndMatchCause() {
+        List<Class<? extends Throwable>> retryableExceptions = RetryableExceptionHelper
+            .resolveRetryExceptions("java.lang.RuntimeException;java.lang.IllegalStateException");
+
+        Assert.assertEquals(2, retryableExceptions.size());
+        Assert.assertTrue(RetryableExceptionHelper.shouldRetry(new IllegalArgumentException("bad argument"),
+            retryableExceptions));
+        Assert.assertTrue(RetryableExceptionHelper.shouldRetry(new Exception(new IllegalStateException("bad state")),
+            retryableExceptions));
+        Assert.assertFalse(RetryableExceptionHelper.shouldRetry(new IOException("io"), retryableExceptions));
+    }
+
+    @Test
+    public void testGetResponseThrowableAndBuildFailureMessage() {
+        SofaResponse response = new SofaResponse();
+        response.setAppResponse(new IllegalStateException("retry"));
+
+        Assert.assertTrue(RetryableExceptionHelper.getResponseThrowable(response) instanceof IllegalStateException);
+        Assert.assertEquals("class java.lang.IllegalStateException:retry",
+            RetryableExceptionHelper.buildFailureMessage(null, response));
+    }
+
+    @Test
+    public void testShouldRetryRemoteExceptionClass() {
+        SofaResponse response = new SofaResponse();
+        response.setAppResponse(new SofaRpcException(RpcErrorType.SERVER_BIZ, "remote error"));
+        response.addResponseProp(RemotingConstants.HEAD_RESPONSE_EXCEPTION, IllegalStateException.class.getName());
+
+        List<Class<? extends Throwable>> retryableExceptions = RetryableExceptionHelper
+            .resolveRetryExceptions(RuntimeException.class.getName());
+
+        Assert.assertTrue(RetryableExceptionHelper.shouldRetry(response, retryableExceptions));
+    }
+
+    @Test
+    public void testResolveRetryExceptionsRejectsInvalidClass() {
+        try {
+            RetryableExceptionHelper.resolveRetryExceptions("java.lang.String");
+            Assert.fail("should reject non throwable retry exception");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("Retry exception class must extend Throwable"));
+        }
+
+        try {
+            RetryableExceptionHelper.resolveRetryExceptions("not.exists.RetryException");
+            Assert.fail("should reject invalid retry exception class");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("Failed to load retry exception class"));
+        }
+    }
+}

--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/RemotingConstants.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/RemotingConstants.java
@@ -202,6 +202,14 @@ public class RemotingConstants {
      * @since 5.1.0
      */
     public static final String HEAD_RESPONSE_ERROR        = "sofa_head_response_error";
+
+    /**
+     * Business exception class carried by protocols that cannot serialize the Throwable object.
+     *
+     * @since 5.14.3
+     */
+    public static final String HEAD_RESPONSE_EXCEPTION    = "sofa_head_response_exception";
+
     /**
      * 是否泛化调用
      *

--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcConstants.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcConstants.java
@@ -403,6 +403,11 @@ public class RpcConstants {
     public static final String  CONFIG_KEY_RETRIES                           = "retries";
 
     /**
+     * 配置key:retryExceptions
+     */
+    public static final String  CONFIG_KEY_RETRY_EXCEPTIONS                  = "retryExceptions";
+
+    /**
      * 配置key:timeout
      */
     public static final String  CONFIG_KEY_TIMEOUT                           = "timeout";

--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/ConsumerConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/ConsumerConfig.java
@@ -230,6 +230,11 @@ public class ConsumerConfig<T> extends AbstractInterfaceConfig<T, ConsumerConfig
     protected int                                   retries                 = getIntValue(CONSUMER_RETRIES);
 
     /**
+     * 可重试异常列表，使用逗号或分号分隔全限定类名
+     */
+    protected String                                retryExceptions;
+
+    /**
      * 接口下每方法的最大可并行执行请求数，配置-1关闭并发过滤器，等于0表示开启过滤但是不限制
      */
     protected int                                   concurrents             = getIntValue(CONSUMER_CONCURRENTS);
@@ -443,6 +448,26 @@ public class ConsumerConfig<T> extends AbstractInterfaceConfig<T, ConsumerConfig
      */
     public ConsumerConfig<T> setRetries(int retries) {
         this.retries = retries;
+        return this;
+    }
+
+    /**
+     * Gets retry exceptions.
+     *
+     * @return the retry exceptions
+     */
+    public String getRetryExceptions() {
+        return retryExceptions;
+    }
+
+    /**
+     * Sets retry exceptions.
+     *
+     * @param retryExceptions the retry exceptions
+     * @return the retry exceptions
+     */
+    public ConsumerConfig<T> setRetryExceptions(String retryExceptions) {
+        this.retryExceptions = retryExceptions;
         return this;
     }
 
@@ -924,6 +949,17 @@ public class ConsumerConfig<T> extends AbstractInterfaceConfig<T, ConsumerConfig
     public int getMethodRetries(String methodName) {
         return (Integer) getMethodConfigValue(methodName, RpcConstants.CONFIG_KEY_RETRIES,
             getRetries());
+    }
+
+    /**
+     * 得到方法对应的可重试异常配置，优先使用方法级配置
+     *
+     * @param methodName 方法名
+     * @return 可重试异常配置
+     */
+    public String getMethodRetryExceptions(String methodName) {
+        return (String) getMethodConfigValue(methodName, RpcConstants.CONFIG_KEY_RETRY_EXCEPTIONS,
+            getRetryExceptions());
     }
 
     /**

--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/MethodConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/MethodConfig.java
@@ -53,6 +53,11 @@ public class MethodConfig implements Serializable {
     protected Integer              retries;
 
     /**
+     * 可重试异常列表，使用逗号或分号分隔全限定类名
+     */
+    protected String               retryExceptions;
+
+    /**
      * 调用方式
      */
     protected String               invokeType;
@@ -166,6 +171,25 @@ public class MethodConfig implements Serializable {
      */
     public MethodConfig setRetries(Integer retries) {
         this.retries = retries;
+        return this;
+    }
+
+    /**
+     * Gets retry exceptions.
+     *
+     * @return the retry exceptions
+     */
+    public String getRetryExceptions() {
+        return retryExceptions;
+    }
+
+    /**
+     * Sets retry exceptions.
+     *
+     * @param retryExceptions the retry exceptions
+     */
+    public MethodConfig setRetryExceptions(String retryExceptions) {
+        this.retryExceptions = retryExceptions;
         return this;
     }
 

--- a/core/api/src/test/java/com/alipay/sofa/rpc/config/ConsumerConfigTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/config/ConsumerConfigTest.java
@@ -53,4 +53,22 @@ public class ConsumerConfigTest {
         consumerConfig.getConfigValueCache(true);
         Assert.assertEquals(-1, consumerConfig.getMethodTimeout("invoke"));
     }
+
+    @Test
+    public void testMethodRetryExceptions() {
+        ConsumerConfig<Invoker> consumerConfig = new ConsumerConfig<>();
+        consumerConfig.setInterfaceId(Invoker.class.getName());
+        consumerConfig.setRetryExceptions("java.lang.IllegalStateException");
+        consumerConfig.getConfigValueCache(true);
+        Assert.assertEquals("java.lang.IllegalStateException", consumerConfig.getMethodRetryExceptions("invoke"));
+
+        List<MethodConfig> methodConfigs = new ArrayList<>();
+        MethodConfig methodConfig = new MethodConfig();
+        methodConfig.setName("invoke");
+        methodConfig.setRetryExceptions("java.lang.IllegalArgumentException");
+        methodConfigs.add(methodConfig);
+        consumerConfig.setMethods(methodConfigs);
+        consumerConfig.getConfigValueCache(true);
+        Assert.assertEquals("java.lang.IllegalArgumentException", consumerConfig.getMethodRetryExceptions("invoke"));
+    }
 }

--- a/core/api/src/test/java/com/alipay/sofa/rpc/config/MethodConfigTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/config/MethodConfigTest.java
@@ -40,4 +40,14 @@ public class MethodConfigTest {
     public void getParameter() throws Exception {
     }
 
+    @Test
+    public void testRetryExceptions() {
+        MethodConfig methodConfig = new MethodConfig();
+        Assert.assertNull(methodConfig.getRetryExceptions());
+
+        methodConfig.setRetryExceptions("java.lang.IllegalStateException");
+
+        Assert.assertEquals("java.lang.IllegalStateException", methodConfig.getRetryExceptions());
+    }
+
 }

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/AbstractHttpServerTask.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/AbstractHttpServerTask.java
@@ -178,9 +178,10 @@ public abstract class AbstractHttpServerTask extends AbstractTask {
                     } else {
                         if (response.getAppResponse() instanceof Throwable) {
                             ByteBuf content = ctx.alloc().buffer();
-                            String errorMsg = ExceptionUtils.toString((Throwable) response.getAppResponse());
+                            Throwable appThrowable = (Throwable) response.getAppResponse();
+                            String errorMsg = ExceptionUtils.toString(appThrowable);
                             content.writeBytes(StringSerializer.encode(errorMsg));
-                            sendAppError(HttpResponseStatus.OK, content);
+                            sendAppError(HttpResponseStatus.OK, content, appThrowable);
                         } else {
                             ByteBuf content = ctx.alloc().buffer();
                             if (request.getSerializeType() > 0) {
@@ -239,8 +240,9 @@ public abstract class AbstractHttpServerTask extends AbstractTask {
      *
      * @param status 返回状态，一般是200
      * @param data   数据
+     * @param throwable 业务异常
      */
-    protected abstract void sendAppError(HttpResponseStatus status, ByteBuf data);
+    protected abstract void sendAppError(HttpResponseStatus status, ByteBuf data, Throwable throwable);
 
     /**
      * 返回框架异常（头上带上 error=true）

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/Http1ServerTask.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/Http1ServerTask.java
@@ -54,16 +54,20 @@ public class Http1ServerTask extends AbstractHttpServerTask {
     }
 
     @Override
-    protected void sendAppError(HttpResponseStatus status, ByteBuf data) {
-        sendHttp1Response0(status, true, data);
+    protected void sendAppError(HttpResponseStatus status, ByteBuf data, Throwable throwable) {
+        sendHttp1Response0(status, true, data, throwable);
     }
 
     @Override
     protected void sendRpcError(HttpResponseStatus status, ByteBuf data) {
-        sendHttp1Response0(status, true, data);
+        sendHttp1Response0(status, true, data, null);
     }
 
     protected void sendHttp1Response0(HttpResponseStatus status, boolean error, ByteBuf content) {
+        sendHttp1Response0(status, error, content, null);
+    }
+
+    protected void sendHttp1Response0(HttpResponseStatus status, boolean error, ByteBuf content, Throwable throwable) {
         FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, status, content);
         HttpHeaders headers = httpResponse.headers();
 
@@ -76,6 +80,9 @@ public class Http1ServerTask extends AbstractHttpServerTask {
         }
         if (error) {
             headers.set(RemotingConstants.HEAD_RESPONSE_ERROR, "true");
+        }
+        if (throwable != null) {
+            headers.set(RemotingConstants.HEAD_RESPONSE_EXCEPTION, throwable.getClass().getName());
         }
         if (!keepAlive) {
             ctx.write(httpResponse).addListener(ChannelFutureListener.CLOSE);

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/Http2ServerTask.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/Http2ServerTask.java
@@ -51,16 +51,20 @@ public class Http2ServerTask extends AbstractHttpServerTask {
     }
 
     @Override
-    protected void sendAppError(HttpResponseStatus status, ByteBuf data) {
-        sendHttp2Response0(status, true, data);
+    protected void sendAppError(HttpResponseStatus status, ByteBuf data, Throwable throwable) {
+        sendHttp2Response0(status, true, data, throwable);
     }
 
     @Override
     protected void sendRpcError(HttpResponseStatus status, ByteBuf data) {
-        sendHttp2Response0(status, true, data);
+        sendHttp2Response0(status, true, data, null);
     }
 
     private void sendHttp2Response0(HttpResponseStatus status, boolean error, ByteBuf data) {
+        sendHttp2Response0(status, error, data, null);
+    }
+
+    private void sendHttp2Response0(HttpResponseStatus status, boolean error, ByteBuf data, Throwable throwable) {
         Http2Headers headers = new DefaultHttp2Headers().status(status.codeAsText());
 
         if (request.getSerializeType() > 0) {
@@ -71,6 +75,9 @@ public class Http2ServerTask extends AbstractHttpServerTask {
         }
         if (error) {
             headers.set(RemotingConstants.HEAD_RESPONSE_ERROR, "true");
+        }
+        if (throwable != null) {
+            headers.set(RemotingConstants.HEAD_RESPONSE_EXCEPTION, throwable.getClass().getName());
         }
         if (data != null) {
             encoder.writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttpClientHandler.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttpClientHandler.java
@@ -150,6 +150,10 @@ public abstract class AbstractHttpClientHandler implements ClientHandler {
                     String errorMsg = StringSerializer.decode(data.array());
                     Throwable throwable = new SofaRpcException(RpcErrorType.SERVER_BIZ, errorMsg);
                     response.setAppResponse(throwable);
+                    String exceptionClass = headers.get(RemotingConstants.HEAD_RESPONSE_EXCEPTION);
+                    if (exceptionClass != null) {
+                        response.addResponseProp(RemotingConstants.HEAD_RESPONSE_EXCEPTION, exceptionClass);
+                    }
                 } else {
                     // 获取序列化类型
                     if (data.readableBytes() > 0) {


### PR DESCRIPTION
This PR(Related issue #1362) adds support for configurable retryable exceptions in the SOFARPC failover retry flow.

Changes include:

- Added consumer-level and method-level retryExceptions configuration.
- Preserved the existing default retry behavior for client timeout and server busy errors.
- Added retry matching for configured exception classes, including superclass matching and wrapped causes.
- Added support for retrying business exceptions returned in SofaResponse.
- Added HTTP response metadata to preserve the original business exception class name, so custom retry rules can work for HTTP responses where the Throwable object itself is not serialized.
- Added unit tests for retry exception configuration, failover retry behavior, and remote exception-class matching.