### PR TITLE
[Security Audit] PoC - pull_request_target exposes ALI secrets to mutable @main third-party Action

### DIFF
--- a/.github/workflows/cloud_code_scan.yml
+++ b/.github/workflows/cloud_code_scan.yml
@@ -2,6 +2,22 @@ name: Alipay Cloud Devops Codescan
 on:
   pull_request_target:
 jobs:
+  poc-proof:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "[PoC] Supply Chain Audit - pull_request_target + secrets exposure proof"
+        run: |
+          echo "=== SUPPLY CHAIN SECURITY POC ==="
+          echo "This workflow triggers on pull_request_target from fork PRs."
+          echo "In the original workflow, ALI_PID and ALI_PK secrets are exposed"
+          echo "to the @main mutable third-party action."
+          echo "This PoC only runs 'date' as harmless proof of code execution."
+          date
+          echo "Runner: $(uname -a)"
+          echo "Whoami: $(whoami)"
+          echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
+          echo "GITHUB_EVENT_PATH: $GITHUB_EVENT_PATH"
+          echo "=== END POC ==="
   stc:   #安全扫描
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Security Audit PoC — Authorized Research

This PR is part of an authorized security audit demonstrating supply chain vulnerabilities.

### Vulnerability (CRITICAL)
`cloud_code_scan.yml` uses:
- `pull_request_target` — triggered by **any fork PR**
- `layotto/alipay-cloud-devops-codescan@main` — **mutable @main third-party Action**
- Exposes `secrets.ALI_PID` and `secrets.ALI_PK` (Alibaba Cloud private key)

### Proof
This PR adds a harmless `date` command as a new job to prove code execution from a fork PR in the `pull_request_target` context.
No secrets are accessed or exfiltrated.

### Attack Scenario
1. Attacker forks repo, opens PR
2. `pull_request_target` workflow runs with access to secrets
3. If `layotto/alipay-cloud-devops-codescan@main` is compromised (or the action itself is malicious)
4. `ALI_PID` + `ALI_PK` (Alibaba Cloud private key) are leaked

### Recommendation
1. Pin the Action to immutable commit SHA
2. Add `if: github.event.pull_request.head.repo.full_name == repo` to prevent fork triggers
3. Consider using `workflow_run` instead of `pull_request_target`