### PR TITLE
fix: add thread-safety for StreamObserver concurrent onNext calls

### DIFF
--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/message/triple/stream/ResponseSerializeSofaStreamObserver.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/message/triple/stream/ResponseSerializeSofaStreamObserver.java
@@ -25,6 +25,8 @@ import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
 import triple.Response;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * Response serialize stream handler.
  */
@@ -32,9 +34,13 @@ public class ResponseSerializeSofaStreamObserver<T> implements SofaStreamObserve
 
     private final StreamObserver<triple.Response> streamObserver;
 
-    private Serializer                            serializer;
+    // ReentrantLock instead of synchronized to avoid virtual thread pinning (JDK 21+)
+    private final ReentrantLock                   writeLock = new ReentrantLock();
 
-    private String                                serializeType;
+    // volatile ensures safe publication when setSerializeType() is called from another thread
+    private volatile Serializer                   serializer;
+
+    private volatile String                       serializeType;
 
     public ResponseSerializeSofaStreamObserver(StreamObserver<triple.Response> streamObserver, String serializeType) {
         this.streamObserver = streamObserver;
@@ -44,6 +50,7 @@ public class ResponseSerializeSofaStreamObserver<T> implements SofaStreamObserve
         }
     }
 
+    // gRPC StreamObserver is not thread-safe, use ReentrantLock to avoid virtual thread pinning (JDK 21+)
     @Override
     public void onNext(T message) {
         Response.Builder builder = Response.newBuilder();
@@ -51,17 +58,32 @@ public class ResponseSerializeSofaStreamObserver<T> implements SofaStreamObserve
         builder.setSerializeType(serializeType);
         builder.setData(ByteString.copyFrom(serializer.encode(message, null).array()));
 
-        streamObserver.onNext(builder.build());
+        writeLock.lock();
+        try {
+            streamObserver.onNext(builder.build());
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     @Override
     public void onCompleted() {
-        streamObserver.onCompleted();
+        writeLock.lock();
+        try {
+            streamObserver.onCompleted();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     @Override
     public void onError(Throwable throwable) {
-        streamObserver.onError(TripleExceptionUtils.asStatusRuntimeException(throwable));
+        writeLock.lock();
+        try {
+            streamObserver.onError(TripleExceptionUtils.asStatusRuntimeException(throwable));
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     public void setSerializeType(String serializeType) {

--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientInvoker.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/transport/triple/TripleClientInvoker.java
@@ -60,6 +60,7 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.alipay.sofa.rpc.common.RpcConstants.SERIALIZE_HESSIAN2;
 import static com.alipay.sofa.rpc.constant.TripleConstant.UNIQUE_ID;
@@ -197,22 +198,39 @@ public class TripleClientInvoker implements TripleInvoker {
                         ClassLoaderUtils.getCurrentClassLoader()
                 )
         );
+        // gRPC StreamObserver is not thread-safe, use ReentrantLock to avoid virtual thread pinning (JDK 21+)
+        final ReentrantLock writeLock = new ReentrantLock();
         SofaStreamObserver<Request> handler = new SofaStreamObserver() {
             @Override
             public void onNext(Object message) {
                 Object[] args = new Object[]{message};
                 Request req = SofaProtoUtils.buildRequest(rebuildTrueRequestArgSigs(args), args, serialization, serializer, 0);
-                observer.onNext(req);
+                writeLock.lock();
+                try {
+                    observer.onNext(req);
+                } finally {
+                    writeLock.unlock();
+                }
             }
 
             @Override
             public void onCompleted() {
-                observer.onCompleted();
+                writeLock.lock();
+                try {
+                    observer.onCompleted();
+                } finally {
+                    writeLock.unlock();
+                }
             }
 
             @Override
             public void onError(Throwable throwable) {
-                observer.onError(TripleExceptionUtils.asStatusRuntimeException(throwable));
+                writeLock.lock();
+                try {
+                    observer.onError(TripleExceptionUtils.asStatusRuntimeException(throwable));
+                } finally {
+                    writeLock.unlock();
+                }
             }
         };
         SofaResponse sofaResponse = new SofaResponse();

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/HelloService.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/HelloService.java
@@ -20,11 +20,13 @@ import com.alipay.sofa.rpc.transport.SofaStreamObserver;
 
 public interface HelloService extends ParentService {
 
-    String CMD_TRIGGER_STREAM_FINISH = "finish";
+    String CMD_TRIGGER_STREAM_FINISH          = "finish";
 
-    String CMD_TRIGGER_STREAM_ERROR  = "error";
+    String CMD_TRIGGER_STREAM_ERROR           = "error";
 
-    String ERROR_MSG                 = "error msg";
+    String CMD_TRIGGER_CONCURRENT_SERVER_SEND = "concurrent_server_send";
+
+    String ERROR_MSG                          = "error msg";
 
     SofaStreamObserver<ClientRequest> sayHelloBiStream(SofaStreamObserver<ServerResponse> sofaStreamObserver);
 

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/HelloServiceImpl.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/HelloServiceImpl.java
@@ -20,6 +20,11 @@ import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 import com.alipay.sofa.rpc.transport.SofaStreamObserver;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 public class HelloServiceImpl implements HelloService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HelloServiceImpl.class);
@@ -63,18 +68,48 @@ public class HelloServiceImpl implements HelloService {
     @Override
     public void sayHelloServerStream(ClientRequest clientRequest, SofaStreamObserver<ServerResponse> sofaStreamObserver) {
         LOGGER.info("server stream req receive");
-        sofaStreamObserver.onNext(new ServerResponse(clientRequest.getMsg(), clientRequest.getCount()));
-        sofaStreamObserver.onNext(new ExtendServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 1,
-            "extendString"));
-        sofaStreamObserver.onNext(new ServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 2));
-        sofaStreamObserver.onNext(new ExtendServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 3,
-            "extendString"));
-        sofaStreamObserver.onNext(new ServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 4));
-        if (clientRequest.getMsg().equals(CMD_TRIGGER_STREAM_ERROR)) {
-            sofaStreamObserver.onError(new RuntimeException(ERROR_MSG));
+        if (clientRequest.getMsg().equals(CMD_TRIGGER_CONCURRENT_SERVER_SEND)) {
+            // Concurrent server send: use multiple threads to send responses simultaneously
+            int totalMessages = clientRequest.getCount();
+            int threadCount = 4;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(totalMessages);
+            for (int i = 0; i < totalMessages; i++) {
+                final int index = i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    try {
+                        sofaStreamObserver.onNext(new ServerResponse(CMD_TRIGGER_CONCURRENT_SERVER_SEND, index));
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+            startLatch.countDown();
+            try {
+                doneLatch.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             sofaStreamObserver.onCompleted();
         } else {
-            sofaStreamObserver.onCompleted();
+            sofaStreamObserver.onNext(new ServerResponse(clientRequest.getMsg(), clientRequest.getCount()));
+            sofaStreamObserver.onNext(new ExtendServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 1,
+                "extendString"));
+            sofaStreamObserver.onNext(new ServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 2));
+            sofaStreamObserver.onNext(new ExtendServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 3,
+                "extendString"));
+            sofaStreamObserver.onNext(new ServerResponse(clientRequest.getMsg(), clientRequest.getCount() + 4));
+            if (clientRequest.getMsg().equals(CMD_TRIGGER_STREAM_ERROR)) {
+                sofaStreamObserver.onError(new RuntimeException(ERROR_MSG));
+            } else {
+                sofaStreamObserver.onCompleted();
+            }
         }
     }
 

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/TripleGenericStreamTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/triple/stream/TripleGenericStreamTest.java
@@ -34,8 +34,11 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -169,6 +172,9 @@ public class TripleGenericStreamTest {
     }
 
     public void testTripleBiStream(boolean endWithException) throws InterruptedException {
+        // Reset mock invocation history to avoid interference between test methods
+        Mockito.reset(helloServiceInst);
+
         int requestTimes = 5;
         CountDownLatch countDownLatch = new CountDownLatch(requestTimes + 1);
 
@@ -290,6 +296,121 @@ public class TripleGenericStreamTest {
         }
         Assert.assertEquals("Expected response count", responseTimes, count.get());
         verify(helloServiceInst, times(1)).sayHelloServerStream(any(), any());
+    }
+
+    /**
+     * Test concurrent client sends on BiStream.
+     * Multiple threads call onNext simultaneously to verify no data is lost.
+     */
+    @Test
+    public void testConcurrentClientSendBiStream() throws InterruptedException {
+        int totalMessages = 100;
+        int threadCount = 8;
+
+        // totalMessages echo responses + 1 onCompleted
+        CountDownLatch responseLatch = new CountDownLatch(totalMessages + 1);
+        List<ServerResponse> receivedResponses = Collections.synchronizedList(new ArrayList<>());
+        AtomicBoolean receivedFinish = new AtomicBoolean(false);
+
+        SofaStreamObserver<ClientRequest> clientSender = helloServiceRef
+                .sayHelloBiStream(new SofaStreamObserver<ServerResponse>() {
+                    @Override
+                    public void onNext(ServerResponse message) {
+                        receivedResponses.add(message);
+                        responseLatch.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        receivedFinish.set(true);
+                        responseLatch.countDown();
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        LOGGER.error("Concurrent bi-stream error", throwable);
+                        responseLatch.countDown();
+                    }
+                });
+
+        // Use multiple threads to send concurrently
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch sendDoneLatch = new CountDownLatch(totalMessages);
+
+        for (int i = 0; i < totalMessages; i++) {
+            final int index = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                try {
+                    clientSender.onNext(new ClientRequest(HELLO_MSG, index));
+                } finally {
+                    sendDoneLatch.countDown();
+                }
+            });
+        }
+
+        // Release all threads at once to maximize concurrency
+        startLatch.countDown();
+        executor.shutdown();
+        Assert.assertTrue("Client send timed out", sendDoneLatch.await(30, TimeUnit.SECONDS));
+
+        // Signal server to finish
+        clientSender.onNext(new ClientRequest(HelloService.CMD_TRIGGER_STREAM_FINISH, -1));
+
+        Assert.assertTrue("Response timed out", responseLatch.await(30, TimeUnit.SECONDS));
+
+        LOGGER.info("Client sent {} messages, client got back {} echo responses",
+                totalMessages, receivedResponses.size());
+
+        Assert.assertTrue("Stream should be completed", receivedFinish.get());
+        Assert.assertEquals("Client should receive all echo responses (no data loss)", totalMessages, receivedResponses.size());
+    }
+
+    /**
+     * Test concurrent server sends on ServerStream.
+     * Server uses multiple threads to call onNext simultaneously to verify no data is lost.
+     */
+    @Test
+    public void testConcurrentServerSendServerStream() throws InterruptedException {
+        int totalMessages = 100;
+        CountDownLatch responseLatch = new CountDownLatch(totalMessages + 1);
+        List<ServerResponse> receivedResponses = Collections.synchronizedList(new ArrayList<>());
+        AtomicBoolean receivedFinish = new AtomicBoolean(false);
+
+        helloServiceRef.sayHelloServerStream(
+                new ClientRequest(HelloService.CMD_TRIGGER_CONCURRENT_SERVER_SEND, totalMessages),
+                new SofaStreamObserver<ServerResponse>() {
+                    @Override
+                    public void onNext(ServerResponse message) {
+                        receivedResponses.add(message);
+                        responseLatch.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        receivedFinish.set(true);
+                        responseLatch.countDown();
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        LOGGER.error("Concurrent server-stream error", throwable);
+                        responseLatch.countDown();
+                    }
+                });
+
+        Assert.assertTrue("Server stream timed out", responseLatch.await(30, TimeUnit.SECONDS));
+
+        LOGGER.info("Server sent {} messages concurrently, client received {} responses",
+                totalMessages, receivedResponses.size());
+
+        Assert.assertTrue("Stream should be completed", receivedFinish.get());
+        Assert.assertEquals("Client should receive all messages", totalMessages, receivedResponses.size());
     }
 
     private void assertServerResponseType(List<ServerResponse> serverResponseList) {


### PR DESCRIPTION
## Problem

gRPC `StreamObserver` is not thread-safe ([javadoc](https://grpc.github.io/grpc-java/javadoc/io/grpc/stub/StreamObserver.html)). When multiple threads call `onNext()` concurrently on the same `StreamObserver` instance, HTTP/2 data frames can get corrupted or lost silently.

### Root Cause

In a real-world streaming scenario, two threads (`grpc-default-executor-4282` and `RTCFrameCallback`) called `onNext()` at the exact same timestamp (`00:00:56.985`), causing frames #936 and #937 to be lost — the server never received them.

## Solution

Add `ReentrantLock` to protect all calls (`onNext`/`onCompleted`/`onError`) to the underlying gRPC `StreamObserver`:

- **Client-side**: `TripleClientInvoker.genericBinaryStreamCall()` — the `SofaStreamObserver` handler returned to user code
- **Server-side**: `ResponseSerializeSofaStreamObserver` — the wrapper around server response `StreamObserver`

### Why ReentrantLock over synchronized?

`synchronized` causes **virtual thread pinning** on JDK 21+ — the virtual thread cannot unmount from its carrier thread while inside a `synchronized` block, potentially exhausting the carrier thread pool. `ReentrantLock` does not have this issue.

### Serialization stays outside the lock

The lock only protects the actual `observer.onNext()` call. Serialization (`buildRequest`, `Response.Builder`) happens **before** acquiring the lock, keeping the critical section minimal.

## Testing

Added two integration tests in `TripleGenericStreamTest`:
- `testConcurrentClientSendBiStream`: 8 threads concurrently send 100 messages via BiStream, verifies no data loss
- `testConcurrentServerSendServerStream`: Server uses 4 threads to concurrently send 100 messages, verifies client receives all