### PR TITLE
fix: parse request baggage from triple headers on server side

### DIFF
--- a/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/TripleTracerAdapter.java
+++ b/remoting/remoting-triple/src/main/java/com/alipay/sofa/rpc/tracer/sofatracer/TripleTracerAdapter.java
@@ -287,6 +287,13 @@ public class TripleTracerAdapter {
             if (!traceMap.isEmpty()) {
                 sofaRequest.addRequestProp(RemotingConstants.RPC_TRACE_NAME, traceMap);
             }
+
+            // 解析请求 baggage：客户端通过 flatCopyTo 将 baggage Map 展平为 rpc_req_baggage.xxx 写入 header，
+            // 此处还原为 Map 放入 requestProps，供 ProviderBaggageFilter 通过 BaggageResolver.pickupFromRequest 解析
+            if (RpcInvokeContext.isBaggageEnable()) {
+                parseBaggageHeaders(requestHeaders, sofaRequest);
+            }
+
             MethodDescriptor.MethodType methodType = call.getMethodDescriptor().getType();
             switch (methodType) {
                 case CLIENT_STREAMING:
@@ -383,5 +390,22 @@ public class TripleTracerAdapter {
             LOGGER.warn("Failed to parse tri-unit-info: " + unitInfo, e);
         }
         return null;
+    }
+
+    private static void parseBaggageHeaders(Metadata requestHeaders, SofaRequest sofaRequest) {
+        String prefix = RemotingConstants.RPC_REQUEST_BAGGAGE + ".";
+        Map<String, String> requestBaggage = new HashMap<>();
+        for (String key : requestHeaders.keys()) {
+            if (key.startsWith(prefix)) {
+                String baggageKey = key.substring(prefix.length());
+                String value = requestHeaders.get(TripleHeadKeys.getKey(key));
+                if (StringUtils.isNotBlank(baggageKey) && value != null) {
+                    requestBaggage.put(baggageKey, value);
+                }
+            }
+        }
+        if (!requestBaggage.isEmpty()) {
+            sofaRequest.addRequestProp(RemotingConstants.RPC_REQUEST_BAGGAGE, requestBaggage);
+        }
     }
 }

--- a/remoting/remoting-triple/src/test/java/com/alipay/sofa/rpc/tracer/sofatracer/TripleTracerAdapterTest.java
+++ b/remoting/remoting-triple/src/test/java/com/alipay/sofa/rpc/tracer/sofatracer/TripleTracerAdapterTest.java
@@ -16,13 +16,22 @@
  */
 package com.alipay.sofa.rpc.tracer.sofatracer;
 
+import com.alipay.sofa.rpc.common.RemotingConstants;
 import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.context.RpcInvokeContext;
 import com.alipay.sofa.rpc.core.request.SofaRequest;
 import com.alipay.sofa.rpc.server.triple.TripleHeadKeys;
+import io.grpc.Attributes;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,6 +60,55 @@ public class TripleTracerAdapterTest {
         Assert.assertEquals("triple.header.value", metadata.get(TripleHeadKeys.getKey("triple.header.key")));
         Assert.assertEquals("value1", metadata.get(TripleHeadKeys.getKey("triple.header.object.key1")));
         Assert.assertEquals("value2", metadata.get(TripleHeadKeys.getKey("triple.header.object.key2")));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testServerReceivedParseBaggage() throws Exception {
+        // 通过反射开启 baggage
+        Field baggageField = RpcInvokeContext.class.getDeclaredField("BAGGAGE_ENABLE");
+        baggageField.setAccessible(true);
+        boolean originEnable = (boolean) baggageField.get(null);
+        try {
+            baggageField.set(null, true);
+
+            // 构造 gRPC Metadata，模拟客户端 flatCopyTo 后的展平 baggage header
+            Metadata requestHeaders = new Metadata();
+            String baggagePrefix = RemotingConstants.RPC_REQUEST_BAGGAGE + ".";
+            requestHeaders.put(TripleHeadKeys.getKey(baggagePrefix + "key1"), "value1");
+            requestHeaders.put(TripleHeadKeys.getKey(baggagePrefix + "key2"), "value2");
+            requestHeaders.put(TripleHeadKeys.HEAD_KEY_TARGET_SERVICE, "com.test.TestService");
+
+            // Mock ServerCall
+            ServerCall<Object, Object> serverCall = Mockito.mock(ServerCall.class);
+            MethodDescriptor<Object, Object> methodDescriptor = MethodDescriptor.newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName("com.test.TestService/testMethod")
+                .setRequestMarshaller(Mockito.mock(MethodDescriptor.Marshaller.class))
+                .setResponseMarshaller(Mockito.mock(MethodDescriptor.Marshaller.class))
+                .build();
+            Mockito.when(serverCall.getMethodDescriptor()).thenReturn(methodDescriptor);
+            Mockito.when(serverCall.getAttributes()).thenReturn(Attributes.EMPTY);
+
+            // Mock ServerServiceDefinition
+            ServiceDescriptor serviceDescriptor = ServiceDescriptor.newBuilder("com.test.TestService").build();
+            ServerServiceDefinition serverServiceDefinition = ServerServiceDefinition.builder(serviceDescriptor)
+                .build();
+
+            SofaRequest sofaRequest = new SofaRequest();
+            TripleTracerAdapter.serverReceived(sofaRequest, serverServiceDefinition, serverCall, requestHeaders);
+
+            // 验证 baggage 已正确放入 SofaRequest.requestProps
+            Map<String, String> baggage = (Map<String, String>) sofaRequest
+                .getRequestProp(RemotingConstants.RPC_REQUEST_BAGGAGE);
+            Assert.assertNotNull("baggage should be parsed from triple headers", baggage);
+            Assert.assertEquals("value1", baggage.get("key1"));
+            Assert.assertEquals("value2", baggage.get("key2"));
+            Assert.assertEquals(2, baggage.size());
+        } finally {
+            baggageField.set(null, originEnable);
+            RpcInvokeContext.removeContext();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

In Triple protocol calls, the server side cannot retrieve client-set baggage via `RpcInvokeContext.getRequestBaggage()`.

## Root Cause

`TripleTracerAdapter.serverReceived()` was missing baggage parsing logic. The client correctly flattens `RpcInvokeContext` request baggage into gRPC metadata headers with prefix `rpc_req_baggage.` (via `CodecUtils.flatCopyTo`), but the server never reconstructed them back into `SofaRequest.requestProps`, causing `ProviderBaggageFilter` → `BaggageResolver.pickupFromRequest()` to find no baggage data.

In contrast, Bolt protocol works correctly because `SofaRpcSerialization.parseRequestHeader()` calls `CodecUtils.treeCopyTo` to restore the flattened headers.

## Fix

Added `parseBaggageHeaders()` method in `TripleTracerAdapter` to extract flattened baggage headers from gRPC Metadata and restore them as a `Map<String, String>` in `SofaRequest.requestProps["rpc_req_baggage"]`, enabling `ProviderBaggageFilter` to work correctly for Triple protocol.

## Changes

- `TripleTracerAdapter.java`: Added baggage header parsing in `serverReceived()` and extracted `parseBaggageHeaders()` method
- `TripleTracerAdapterTest.java`: Added unit test `testServerReceivedParseBaggage` to verify baggage parsing from gRPC Metadata