### PR TITLE
bump version to 5.14.4-SNAPSHOT

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-rpc-all</artifactId>
-    <version>5.14.3</version>
+    <version>5.14.4-SNAPSHOT</version>
 
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>5.14.3</revision>
+        <revision>5.14.4-SNAPSHOT</revision>
         <javassist.version>3.29.2-GA</javassist.version>
         <bytebuddy.version>1.9.8</bytebuddy.version>
         <netty.version>4.1.77.Final</netty.version>

--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/Version.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/Version.java
@@ -27,16 +27,16 @@ public final class Version {
     /**
      * 当前RPC版本，例如：5.6.7
      */
-    public static final String VERSION       = "5.14.3";
+    public static final String VERSION       = "5.14.4";
 
     /**
      * 当前RPC版本，例如： 5.6.7 对应 50607
      */
-    public static final int    RPC_VERSION   = 51403;
+    public static final int    RPC_VERSION   = 51404;
 
     /**
      * 当前Build版本，每次发布修改
      */
-    public static final String BUILD_VERSION = "5.14.3_20260629200518";
+    public static final String BUILD_VERSION = "5.14.4_20260722201313";
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
     <properties>
         <!-- Build args -->
-        <revision>5.14.3</revision>
+        <revision>5.14.4-SNAPSHOT</revision>
         <jmh.version>1.33</jmh.version>
         <module.install.skip>true</module.install.skip>
         <module.deploy.skip>true</module.deploy.skip>


### PR DESCRIPTION
## What
升级版本到 `5.14.4-SNAPSHOT`，为新版本研发做准备。

## Changes
通过 `tools/change_version.sh 5.14.4-SNAPSHOT` 脚本统一升级，涉及：
- `pom.xml`：`revision` → `5.14.4-SNAPSHOT`
- `bom/pom.xml`：`revision` → `5.14.4-SNAPSHOT`
- `all/pom.xml`：`version` → `5.14.4-SNAPSHOT`
- `core/api/.../Version.java`：`VERSION` → `5.14.4`，`RPC_VERSION` → `51404`，`BUILD_VERSION` 同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)