### PR TITLE
fix(http2): enforce payload limit on HTTP/2 server request body to prevent heap exhaustion DoS

### DIFF
--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ChannelHandlerBuilder.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ChannelHandlerBuilder.java
@@ -36,9 +36,15 @@ public final class Http2ChannelHandlerBuilder
 
     private final HttpServerHandler       serverHandler;
 
-    public Http2ChannelHandlerBuilder(HttpServerHandler serverHandler) {
+    /**
+     * HTTP/2 请求体的最大累计长度（字节），透传给 {@link Http2ServerChannelHandler} 做请求体大小限制。
+     */
+    private final int                     maxContentLength;
+
+    public Http2ChannelHandlerBuilder(HttpServerHandler serverHandler, int maxContentLength) {
         frameLogger(LOGGER);
         this.serverHandler = serverHandler;
+        this.maxContentLength = maxContentLength;
     }
 
     @Override
@@ -49,8 +55,8 @@ public final class Http2ChannelHandlerBuilder
     @Override
     protected Http2ServerChannelHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                               Http2Settings initialSettings) {
-        Http2ServerChannelHandler handler = new Http2ServerChannelHandler(serverHandler, decoder, encoder,
-            initialSettings);
+        Http2ServerChannelHandler handler = new Http2ServerChannelHandler(serverHandler, maxContentLength, decoder,
+            encoder, initialSettings);
         frameListener(handler);
         return handler;
     }

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ChannelHandlerBuilder.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ChannelHandlerBuilder.java
@@ -16,6 +16,8 @@
  */
 package com.alipay.sofa.rpc.transport.http;
 
+import com.alipay.sofa.rpc.common.RpcConfigs;
+import com.alipay.sofa.rpc.common.RpcOptions;
 import com.alipay.sofa.rpc.server.http.HttpServerHandler;
 import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
@@ -45,6 +47,14 @@ public final class Http2ChannelHandlerBuilder
         frameLogger(LOGGER);
         this.serverHandler = serverHandler;
         this.maxContentLength = maxContentLength;
+    }
+
+    /**
+     * 兼容旧版本的单参数构造方法：使用默认 payload 上限（{@code transport.payload.max}）。
+     * 保留此重载以维持对外 API 的二进制/源码兼容性。
+     */
+    public Http2ChannelHandlerBuilder(HttpServerHandler serverHandler) {
+        this(serverHandler, RpcConfigs.getIntValue(RpcOptions.TRANSPORT_PAYLOAD_MAX));
     }
 
     @Override

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ServerChannelHandler.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ServerChannelHandler.java
@@ -37,9 +37,11 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionAdapter;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Flags;
 import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -67,13 +69,35 @@ public final class Http2ServerChannelHandler extends Http2ConnectionHandler impl
 
     private final HttpServerHandler           serverHandler;
 
+    /**
+     * HTTP/2 请求体的最大累积长度（字节），与 HTTP/1.1 的 {@code HttpObjectAggregator} 一致，
+     * 取自 {@code ServerTransportConfig.getPayload()}。超出则重置对应 stream，避免恶意客户端
+     * 持续发送 DATA 帧但不发送 END_STREAM 导致堆耗尽。
+     */
+    private final int                         maxContentLength;
+
     private boolean                           isUpgradeH2cMode = false;
 
-    Http2ServerChannelHandler(HttpServerHandler serverHandler, Http2ConnectionDecoder decoder,
-                              Http2ConnectionEncoder encoder,
+    Http2ServerChannelHandler(HttpServerHandler serverHandler, int maxContentLength,
+                              Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                               Http2Settings initialSettings) {
         super(decoder, encoder, initialSettings);
         this.serverHandler = serverHandler;
+        this.maxContentLength = maxContentLength;
+        // stream 关闭时（连接断开 / RST_STREAM / 正常结束）清理尚未消费的累积 ByteBuf，避免内存泄漏
+        connection().addListener(new Http2ConnectionAdapter() {
+            @Override
+            public void onStreamClosed(Http2Stream stream) {
+                ByteBuf buffer = stream.getProperty(messageKey);
+                if (buffer != null) {
+                    stream.removeProperty(messageKey);
+                    if (buffer.refCnt() > 0) {
+                        buffer.release();
+                    }
+                }
+                stream.removeProperty(headerKey);
+            }
+        });
     }
 
     private static Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
@@ -118,17 +142,45 @@ public final class Http2ServerChannelHandler extends Http2ConnectionHandler impl
 
         Http2Stream http2Stream = connection().stream(streamId);
         ByteBuf msg = http2Stream.getProperty(messageKey);
+        final int dataReadableBytes = data.readableBytes();
+
+        // 写入前校验累计长度，防止恶意客户端不发 END_STREAM 持续累积数据导致堆耗尽
+        if (dataReadableBytes > 0) {
+            int accumulated = msg == null ? 0 : msg.readableBytes();
+            if ((long) accumulated + dataReadableBytes > maxContentLength) {
+                if (msg != null) {
+                    msg.release();
+                    http2Stream.removeProperty(messageKey);
+                }
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn("HTTP/2 request body exceeded max payload {} bytes, reset stream {} from {}",
+                        maxContentLength, streamId, NetUtils.channelToString(ctx.channel().remoteAddress(),
+                            ctx.channel().localAddress()));
+                }
+                // 重置该 stream，不进入 handleRequest；返回已消费字节数以推进流控窗口
+                encoder().writeRstStream(ctx, streamId, Http2Error.PROTOCOL_ERROR.code(), ctx.newPromise());
+                return processed;
+            }
+        }
+
         if (msg == null) {
             msg = ctx.alloc().buffer();
             http2Stream.setProperty(messageKey, msg);
         }
-        final int dataReadableBytes = data.readableBytes();
         msg.writeBytes(data, data.readerIndex(), dataReadableBytes);
 
         if (endOfStream) {
             // read cached http2 header from stream
             Http2Headers headers = http2Stream.getProperty(headerKey);
-            handleRequest(ctx, streamId, headers, msg);
+            try {
+                handleRequest(ctx, streamId, headers, msg);
+            } finally {
+                // 请求已同步处理完毕（反序列化+调用+响应已写出），释放累积缓冲并清理缓存
+                http2Stream.removeProperty(messageKey);
+                if (msg.refCnt() > 0) {
+                    msg.release();
+                }
+            }
         }
         return processed;
     }

--- a/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ServerChannelInitializer.java
+++ b/remoting/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/Http2ServerChannelInitializer.java
@@ -93,7 +93,7 @@ public class Http2ServerChannelInitializer extends ChannelInitializer<SocketChan
             protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
                 if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
                     ctx.pipeline().addLast(bizGroup, "Http2ChannelHandler",
-                        new Http2ChannelHandlerBuilder(serverHandler).build());
+                        new Http2ChannelHandlerBuilder(serverHandler, maxHttpContentLength).build());
                     return;
                 }
 
@@ -121,7 +121,8 @@ public class Http2ServerChannelInitializer extends ChannelInitializer<SocketChan
                 @Override
                 public HttpServerUpgradeHandler.UpgradeCodec newUpgradeCodec(CharSequence protocol) {
                     if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                        return new Http2ServerUpgradeCodec(new Http2ChannelHandlerBuilder(serverHandler).build());
+                        return new Http2ServerUpgradeCodec(
+                            new Http2ChannelHandlerBuilder(serverHandler, maxHttpContentLength).build());
                     } else {
                         return null;
                     }
@@ -129,7 +130,7 @@ public class Http2ServerChannelInitializer extends ChannelInitializer<SocketChan
             });
         final Http2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
                 new Http2ServerUpgradeHandler(bizGroup, sourceCodec, upgradeHandler,
-                    new Http2ChannelHandlerBuilder(serverHandler).build());
+                    new Http2ChannelHandlerBuilder(serverHandler, maxHttpContentLength).build());
 
         // 先通过 HTTP Upgrade 协商版本
         p.addLast("Http2ServerUpgradeHandler", cleartextHttp2ServerUpgradeHandler);

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/transport/http/Http2ClearTextPayloadLimitTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/transport/http/Http2ClearTextPayloadLimitTest.java
@@ -136,8 +136,10 @@ public class Http2ClearTextPayloadLimitTest extends ActivelyDestroyTest {
     private MyHandler sendHttpRequest(Http2ClientTransport clientTransport, FullHttpRequest httpRequest)
         throws InterruptedException {
         MyHandler handler = new MyHandler();
-        clientTransport.sendHttpRequest(httpRequest, handler);
+        int requestId = clientTransport.sendHttpRequest(httpRequest, handler);
         handler.latch.await(3, TimeUnit.SECONDS);
+        // 服务端重置 stream 时不会回响应，handler 不会被回调，需主动清理待响应 promise，避免泄漏到后续测试
+        clientTransport.responseChannelHandler.removePromise(requestId);
         return handler;
     }
 

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/transport/http/Http2ClearTextPayloadLimitTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/transport/http/Http2ClearTextPayloadLimitTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.transport.http;
+
+import com.alipay.sofa.rpc.client.ProviderHelper;
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ApplicationConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.server.bolt.pb.EchoRequest;
+import com.alipay.sofa.rpc.server.bolt.pb.EchoResponse;
+import com.alipay.sofa.rpc.server.http.HttpService;
+import com.alipay.sofa.rpc.server.http.HttpServiceImpl;
+import com.alipay.sofa.rpc.test.ActivelyDestroyTest;
+import com.alipay.sofa.rpc.transport.ClientTransportConfig;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+/**
+ * 回归测试：HTTP/2 (h2c) 路径必须对请求体累计长度施加与 HTTP/1.1 一致的 payload 上限，
+ * 超限时重置 stream 且不调用业务方法，避免恶意客户端持续发送 DATA 帧导致堆耗尽 (CWE-770)。
+ *
+ * @author <a href="mailto:liujianjun.ljj@antfin.com">Jianjun Liu</a>
+ */
+public class Http2ClearTextPayloadLimitTest extends ActivelyDestroyTest {
+
+    /**
+     * 业务方法被调用的次数，用于校验超限请求不会进入业务处理。
+     */
+    private final AtomicInteger invoked = new AtomicInteger();
+
+    @Test
+    public void testPayloadLimit() throws Exception {
+        // payload 上限设为 1KiB
+        final int payload = 1024;
+        ServerConfig serverConfig = new ServerConfig()
+            .setStopTimeout(60000)
+            .setPort(12389)
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_H2C)
+            .setPayload(payload)
+            .setDaemon(true);
+
+        HttpService ref = new HttpServiceImpl() {
+            @Override
+            public EchoResponse echoPb(EchoRequest request) {
+                invoked.incrementAndGet();
+                return super.echoPb(request);
+            }
+        };
+        ProviderConfig<HttpService> providerConfig = new ProviderConfig<HttpService>()
+            .setInterfaceId(HttpService.class.getName())
+            .setRef(ref)
+            .setApplication(new ApplicationConfig().setAppName("serverApp"))
+            .setServer(serverConfig)
+            .setRegister(false);
+        providerConfig.export();
+
+        ClientTransportConfig clientTransportConfig = new ClientTransportConfig();
+        clientTransportConfig.setProviderInfo(ProviderHelper.toProviderInfo("h2c://127.0.0.1:12389"));
+        Http2ClientTransport clientTransport = new Http2ClientTransport(clientTransportConfig);
+        clientTransport.connect();
+
+        // 1) 累计长度低于限制的合法请求应当正常处理
+        {
+            FullHttpRequest httpRequest = buildValidRequest();
+            MyHandler handler = sendHttpRequest(clientTransport, httpRequest);
+            Assert.assertNotNull("small request should get a response", handler.response);
+            Assert.assertEquals(200, handler.response.status().code());
+            Assert.assertEquals("service method should be invoked once for the small request", 1, invoked.get());
+        }
+
+        // 2) 累计长度超过限制的请求：必须重置/拒绝，业务方法不得被调用
+        int before = invoked.get();
+        {
+            FullHttpRequest httpRequest = buildOversizedRequest(payload * 2);
+            MyHandler handler = sendHttpRequest(clientTransport, httpRequest);
+            // 不应收到 200 正常响应：要么无响应（流被重置/连接关闭），要么以异常告终
+            boolean got200 = handler.response != null && handler.response.status().code() == 200;
+            Assert.assertFalse("oversized request must not produce a 200 response", got200);
+            Assert.assertEquals("service method must not be invoked for oversized request", before, invoked.get());
+        }
+    }
+
+    /** 构造一个体积远小于 payload 上限的合法 protobuf 请求。 */
+    private FullHttpRequest buildValidRequest() {
+        EchoRequest request = EchoRequest.newBuilder().setName("xxx").build();
+        return buildRequest(request.toByteArray());
+    }
+
+    /** 构造一个体积超过 payload 上限的请求（任意字节填充，仅用于触发体积上限）。 */
+    private FullHttpRequest buildOversizedRequest(int bodySize) {
+        return buildRequest(new byte[bodySize]);
+    }
+
+    private FullHttpRequest buildRequest(byte[] body) {
+        FullHttpRequest httpRequest = new DefaultFullHttpRequest(HTTP_1_1, POST,
+            "http://127.0.0.1:12389/com.alipay.sofa.rpc.server.http.HttpService/echoPb",
+            wrappedBuffer(body));
+        HttpHeaders headers = httpRequest.headers();
+        headers.add(HttpHeaderNames.HOST, "127.0.0.1");
+        headers.add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "HTTP");
+        headers.add(RemotingConstants.HEAD_SERIALIZE_TYPE, "protobuf");
+        return httpRequest;
+    }
+
+    private MyHandler sendHttpRequest(Http2ClientTransport clientTransport, FullHttpRequest httpRequest)
+        throws InterruptedException {
+        MyHandler handler = new MyHandler();
+        clientTransport.sendHttpRequest(httpRequest, handler);
+        handler.latch.await(3, TimeUnit.SECONDS);
+        return handler;
+    }
+
+    private final class MyHandler extends AbstractHttpClientHandler {
+
+        CountDownLatch   latch = new CountDownLatch(1);
+        FullHttpResponse response;
+        Throwable        exception;
+
+        protected MyHandler() {
+            super(null, null, null, null, null);
+        }
+
+        @Override
+        public Executor getExecutor() {
+            return null;
+        }
+
+        @Override
+        public void doOnResponse(Object result) {
+            latch.countDown();
+        }
+
+        @Override
+        public void doOnException(Throwable e) {
+            this.exception = e;
+            latch.countDown();
+        }
+
+        @Override
+        public void receiveHttpResponse(FullHttpResponse response) {
+            this.response = response;
+            latch.countDown();
+        }
+    }
+}


### PR DESCRIPTION
## Background

HTTP/2 (h2/h2c) server path accumulated DATA frames in `Http2ServerChannelHandler.onDataRead` without comparing the accumulated size against `ServerTransportConfig.getPayload()`.

The default 8 MiB payload limit (`transport.payload.max`) was only applied to the HTTP/1.1 pipeline via `HttpObjectAggregator`; the HTTP/2 / h2c pipelines had **no equivalent limit**.

An unauthenticated client that can reach an h2 or h2c listening port can keep a request stream open and continuously send legal DATA frames without sending `END_STREAM`. Because `onDataRead` returns the processed byte count, flow control issues `WINDOW_UPDATE`, so **HTTP/2 flow control does not cap the application-layer request body**. The server retains attacker data before routing / auth / deserialization / RPC invocation until the JVM heap is exhausted.

- **CWE**: CWE-770 (Allocation of Resources Without Limits or Throttling)
- **CVSS v3.1**: 7.5 (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`)

## Reproduction (loopback only)

A stdlib Python client sending up to 80 MiB of DATA frames on a single stream (respecting `WINDOW_UPDATE`, never sending `END_STREAM`) against an h2c target running with `-Xmx64m -XX:+ExitOnOutOfMemoryError` produced:

```
TARGET_CONNECTION_CLOSED after 12599142 bytes
Terminating due to java.lang.OutOfMemoryError: Java heap space
```

12,599,142 bytes exceeds the default 8 MiB (8,388,608) limit, confirming the HTTP/2 path did not enforce it.

## Fix

- **`Http2ServerChannelHandler`**: accept `maxContentLength` (from `transport.payload.max` — same source as `HttpObjectAggregator`). In `onDataRead`, **before** `writeBytes`, check `accumulated + frameSize > maxContentLength`; on overflow release the accumulated `ByteBuf`, reset the stream via `writeRstStream(PROTOCOL_ERROR)`, and **do not call `handleRequest`**. Return processed bytes so flow control stays correct.
- Release the accumulated `msg` after the synchronous `handleRequest` (this also fixes a **pre-existing per-request `ByteBuf` leak**: `AbstractHttpServerTask` never released the request buffer, so every h2 request leaked `msg`).
- Register an `Http2ConnectionAdapter` to release any residual buffer on stream close (connection drop / `RST_STREAM` / normal end) as a backstop.
- **`Http2ChannelHandlerBuilder` / `Http2ServerChannelInitializer`**: thread `maxHttpContentLength` through to the handler for all h2/h2c paths (TLS NPN, prior-knowledge, HTTP/1.1 upgrade).
- **New regression test** `Http2ClearTextPayloadLimitTest`: with `payload=1024`, a valid small request is served (200, method invoked); an oversized request is reset / no 200 and the service method is **not** invoked.

## Verification

- `remoting-http` main + `test-integration` test code compiles.
- New test asserts the limit is enforced; server logs `HTTP/2 request body exceeded max payload 1024 bytes, reset stream ...`.
- Full h2/h2c integration suite (`Http2ClearText*`, `H2c*`, deadline) — 9 tests, 0 failures, no regression.

## Compatibility

Behavior now matches the HTTP/1.1 `HttpObjectAggregator(maxContentLength)` path. Default `transport.payload.max` (8 MiB) is unchanged; HTTP/2 simply enforces it too. Users can still override via `-Dtransport.payload.max`, `META-INF/sofa-rpc/rpc-config.json`, or `ServerConfig.setPayload(...)`.

## Operational note

Before releasing this fix, do not expose h2/h2c listening ports directly to untrusted networks; consider a fronting proxy with request-body limits and conservative JVM memory / OOM policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)